### PR TITLE
Fix WebHooksClient config

### DIFF
--- a/src/WebhookClient/Program.cs
+++ b/src/WebhookClient/Program.cs
@@ -26,7 +26,7 @@ app.MapDefaultControllerRoute();
 app.MapRazorPages();
 
 bool.TryParse(builder.Configuration["ValidateToken"], out var validateToken);
-var tokenToValidate = builder.Configuration["Token"];
+var tokenToValidate = builder.Configuration["WebhookClientOptions:Token"];
 
 app.MapMethods("/check", [HttpMethods.Options], Results<Ok, BadRequest<string>> ([FromHeader(Name = HeaderNames.WebHookCheckHeader)] string value, HttpResponse response) =>
 {


### PR DESCRIPTION
Should "ValidateToken" also come from "WebhookClientOptions"?

https://github.com/dotnet/eShop/blob/b96fcb1eb941fda8e0daaff2a40d3f71998f75b1/src/WebhookClient/appsettings.json#L8-L9