### PR TITLE
Fix up Ordering.FunctionalTests

### DIFF
--- a/tests/Catalog.FunctionalTests/CatalogApiFixture.cs
+++ b/tests/Catalog.FunctionalTests/CatalogApiFixture.cs
@@ -11,7 +11,7 @@ public sealed class CatalogApiFixture : WebApplicationFactory<Program>, IAsyncLi
 
     public CatalogApiFixture()
     {
-        var options = new DistributedApplicationOptions { AssemblyName = typeof(CatalogApiFixture).Assembly.FullName };
+        var options = new DistributedApplicationOptions { AssemblyName = typeof(CatalogApiFixture).Assembly.FullName, DisableDashboard = true };
         var appBuilder = DistributedApplication.CreateBuilder(options);
         Postgres = appBuilder.AddPostgresContainer("CatalogDB")
             .WithAnnotation(new ContainerImageAnnotation

--- a/tests/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
+++ b/tests/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ordering.API\Ordering.API.csproj" />
+    <ProjectReference Include="..\..\src\Identity.API\Identity.API.csproj" />
     <ProjectReference Include="..\..\src\Ordering.Domain\Ordering.Domain.csproj" />
     <ProjectReference Include="..\..\src\Ordering.Infrastructure\Ordering.Infrastructure.csproj" />
   </ItemGroup>

--- a/tests/Ordering.FunctionalTests/OrderingApiFixture.cs
+++ b/tests/Ordering.FunctionalTests/OrderingApiFixture.cs
@@ -8,12 +8,16 @@ public sealed class OrderingApiFixture : WebApplicationFactory<Program>, IAsyncL
     private readonly IHost _app;
 
     public IResourceBuilder<PostgresContainerResource> Postgres { get; private set; }
+    public IResourceBuilder<PostgresContainerResource> IdentityDB { get; private set; }
+    public IResourceBuilder<ProjectResource> IdentityApi { get; private set; }
 
     public OrderingApiFixture()
     {
-        var options = new DistributedApplicationOptions { AssemblyName = typeof(OrderingApiFixture).Assembly.FullName };
+        var options = new DistributedApplicationOptions { AssemblyName = typeof(OrderingApiFixture).Assembly.FullName, DisableDashboard = true };
         var appBuilder = DistributedApplication.CreateBuilder(options);
         Postgres = appBuilder.AddPostgresContainer("OrderingDB");
+        IdentityDB = appBuilder.AddPostgresContainer("IdentityDB");
+        IdentityApi = appBuilder.AddProject<Projects.Identity_API>("identity-api").WithReference(IdentityDB);
         _app = appBuilder.Build();
     }
 
@@ -24,7 +28,12 @@ public sealed class OrderingApiFixture : WebApplicationFactory<Program>, IAsyncL
             config.AddInMemoryCollection(new Dictionary<string, string>
             {
                 { $"ConnectionStrings:{Postgres.Resource.Name}", Postgres.Resource.GetConnectionString() },
-                });
+                { "Identity:Url", IdentityApi.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single().UriString }
+            });
+        });
+        builder.ConfigureServices(services =>
+        {
+            services.AddSingleton<IStartupFilter>(new AutoAuthorizeStartupFilter());
         });
         return base.CreateHost(builder);
     }
@@ -46,5 +55,17 @@ public sealed class OrderingApiFixture : WebApplicationFactory<Program>, IAsyncL
     public async Task InitializeAsync()
     {
         await _app.StartAsync();
+    }
+
+    private class AutoAuthorizeStartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return builder =>
+            {
+                builder.UseMiddleware<AutoAuthorizeMiddleware>();
+                next(builder);
+            };
+        }
     }
 }

--- a/tests/Ordering.FunctionalTests/OrderingApiTests.cs
+++ b/tests/Ordering.FunctionalTests/OrderingApiTests.cs
@@ -33,7 +33,7 @@ public sealed class OrderingApiTests : IClassFixture<OrderingApiFixture>
         {
             Headers = { { "x-requestid", Guid.Empty.ToString() } }
         };
-        var response = await _httpClient.PutAsync("api/v1/orders/cancel", content);
+        var response = await _httpClient.PutAsync("/api/v1/orders/cancel", content);
 
         var s = await response.Content.ReadAsStringAsync();
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);


### PR DESCRIPTION
- Add IdentityAPI as dependency of Ordering.API in tests
- Add AutoAuthorizeMiddleware to automatically set auth tokens
- Disable dashboard on all tests using Aspire app host