### PR TITLE
Use the same pattern that we use for other mains

### DIFF
--- a/src/WebApp/GlobalUsings.cs
+++ b/src/WebApp/GlobalUsings.cs
@@ -1,6 +1,5 @@
 ﻿global using eShop.WebApp.Components;
 global using eShop.WebApp.Services;
-global using eShop.WebApp.Extensions;
 global using eShop.ServiceDefaults;
 global using eShop.EventBus.Abstractions;
 global using eShop.WebApp.Services.OrderStatus.IntegrationEvents;

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -1,25 +1,10 @@
-﻿using eShop.WebAppComponents.Services;
-
-var builder = WebApplication.CreateBuilder(args);
+﻿var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
-builder.AddAuthenticationServices();
-builder.AddRabbitMqEventBus("EventBus")
-       .AddEventBusSubscriptions();
-
-// Application services
-builder.Services.AddScoped<BasketState>();
-builder.Services.AddScoped<LogOutService>();
-builder.Services.AddSingleton<BasketService>();
-builder.Services.AddSingleton<OrderStatusNotificationService>();
-
-// Backend services
-builder.Services.AddGrpcClient<Basket.BasketClient>(o => o.Address = new("http://basket-api")).AddAuthToken();
-builder.Services.AddHttpClient<CatalogService>(o => o.BaseAddress = new("http://catalog-api")).AddAuthToken();
-builder.Services.AddHttpClient<OrderingService>(o => o.BaseAddress = new("http://ordering-api")).AddAuthToken();
+builder.AddApplicationServices();
 
 var app = builder.Build();
 


### PR DESCRIPTION
This pull request to the `WebApp` project adds authentication services, a RabbitMQ event bus, and HTTP and GRPC client registrations. It also removes some unnecessary import statements.

Main changes:

* <a href="diffhunk://#diff-6d9a306a0e97071ff466f4632bb67f1933e38dd95c59ac3c332c0a2eeb0445c5L1-R7">`src/WebApp/Program.cs`</a>: Adds authentication services, RabbitMQ event bus, and HTTP and GRPC client registrations by calling `AddApplicationServices()` and removes the import statement for `eShop.WebAppComponents.Services`.
* <a href="diffhunk://#diff-09204b8099bea694db2846ae7af034ffe74fc94c1d3b6f6d12fc4a81988ec872L65-L74">`src/WebApp/Extensions/Extensions.cs`</a>: Adds a new method `AddApplicationServices()` that adds authentication services, RabbitMQ event bus, and HTTP and GRPC client registrations.
* <a href="diffhunk://#diff-09204b8099bea694db2846ae7af034ffe74fc94c1d3b6f6d12fc4a81988ec872L1-R43">`src/WebApp/Extensions/Extensions.cs`</a>: Adds the `AddEventBusSubscriptions()` method for different order status changed integration events.