### PR TITLE
Retrieve HybridApp images from web app

### DIFF
--- a/src/HybridApp/MauiProgram.cs
+++ b/src/HybridApp/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using eShop.WebAppComponents.Services;
+﻿using eShop.HybridApp.Services;
+using eShop.WebAppComponents.Services;
 using Microsoft.Extensions.Logging;
 
 namespace eShop.HybridApp;
@@ -7,6 +8,8 @@ public static class MauiProgram
 {
     // NOTE: Must have a trailing slash to ensure the full BaseAddress URL is used to resolve relative URLs
     private static string MobileBffBaseUrl = "http://localhost:61632/catalog-api/";
+
+    internal static string ProductImageHostUrl = "https://localhost:7298";
 
     public static MauiApp CreateMauiApp()
     {
@@ -26,6 +29,7 @@ public static class MauiProgram
 #endif
 
         builder.Services.AddHttpClient<CatalogService>(o => o.BaseAddress = new(MobileBffBaseUrl));
+        builder.Services.AddSingleton<IProductImageUrlProvider, ProductImageUrlProvider>();
 
         return builder.Build();
     }

--- a/src/HybridApp/Services/ProductImageUrlProvider.cs
+++ b/src/HybridApp/Services/ProductImageUrlProvider.cs
@@ -1,0 +1,9 @@
+﻿using eShop.WebAppComponents.Services;
+
+namespace eShop.HybridApp.Services;
+
+public class ProductImageUrlProvider : IProductImageUrlProvider
+{
+    public string GetProductImageUrl(int productId) 
+        => $"{MauiProgram.ProductImageHostUrl}/product-images/{productId}";
+}


### PR DESCRIPTION
@SteveSandersonMS - here's a PR to your PR to have the .NET MAUI Hybrid App retrieve images from the web app.

I considered two approaches:

1. The approach in this PR, which is to retrieve images directly from the HTML to the web app. This is quite simple (1 line of code)
1. An alternative would be to do something more akin to the proxy pattern in the webapp, which is to have the Hybrid App get the images from the catalog-api service (via the mobile-bff), and then generate a `data:base64` URL with the image data. This isn't hard to do, but it's more complicated, and more work.

I think both options are technically correct, but I don't know which way we'd want to lean in this app. If (1) is OK, then we can merge this PR into your PR branch. If we want to do (2), then I can get that done instead.