### PR TITLE
vector type max length is 1024 in db

### DIFF
--- a/src/Catalog.API/Infrastructure/EntityConfigurations/CatalogItemEntityTypeConfiguration.cs
+++ b/src/Catalog.API/Infrastructure/EntityConfigurations/CatalogItemEntityTypeConfiguration.cs
@@ -13,7 +13,7 @@ class CatalogItemEntityTypeConfiguration
         builder.Ignore(ci => ci.PictureUri);
 
         builder.Property(ci => ci.Embedding)
-            .HasColumnType("vector(1536)");
+            .HasColumnType("vector(1024)");
 
         builder.HasOne(ci => ci.CatalogBrand)
             .WithMany();

--- a/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.Designer.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.Designer.cs
@@ -74,7 +74,7 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                         .HasColumnType("text");
 
                     b.Property<Vector>("Embedding")
-                        .HasColumnType("vector(1536)");
+                        .HasColumnType("vector(1024)");
 
                     b.Property<int>("MaxStockThreshold")
                         .HasColumnType("integer");

--- a/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.cs
@@ -64,7 +64,7 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                     AvailableStock = table.Column<int>(type: "integer", nullable: false),
                     RestockThreshold = table.Column<int>(type: "integer", nullable: false),
                     MaxStockThreshold = table.Column<int>(type: "integer", nullable: false),
-                    Embedding = table.Column<Vector>(type: "vector(1536)", nullable: true),
+                    Embedding = table.Column<Vector>(type: "vector(1024)", nullable: true),
                     OnReorder = table.Column<bool>(type: "boolean", nullable: false)
                 },
                 constraints: table =>

--- a/src/Catalog.API/Infrastructure/Migrations/20231018163051_RemoveHiLoAndIndexCatalogName.Designer.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/20231018163051_RemoveHiLoAndIndexCatalogName.Designer.cs
@@ -65,7 +65,7 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                         .HasColumnType("text");
 
                     b.Property<Vector>("Embedding")
-                        .HasColumnType("vector(1536)");
+                        .HasColumnType("vector(1024)");
 
                     b.Property<int>("MaxStockThreshold")
                         .HasColumnType("integer");

--- a/src/Catalog.API/Infrastructure/Migrations/20231026091140_Outbox.Designer.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/20231026091140_Outbox.Designer.cs
@@ -66,7 +66,7 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                         .HasColumnType("text");
 
                     b.Property<Vector>("Embedding")
-                        .HasColumnType("vector(1536)");
+                        .HasColumnType("vector(1024)");
 
                     b.Property<int>("MaxStockThreshold")
                         .HasColumnType("integer");

--- a/src/Catalog.API/Infrastructure/Migrations/CatalogContextModelSnapshot.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/CatalogContextModelSnapshot.cs
@@ -63,7 +63,7 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                         .HasColumnType("text");
 
                     b.Property<Vector>("Embedding")
-                        .HasColumnType("vector(1536)");
+                        .HasColumnType("vector(1024)");
 
                     b.Property<int>("MaxStockThreshold")
                         .HasColumnType("integer");


### PR DESCRIPTION
pgsql version : PostgreSQL 14.0 (Debian 14.0-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit

pgsql docker image: ankane/pgvector:latest

docker run command:    docker run --hostname=393104f8245b --mac-address=02:42:ac:11:00:03 --env=POSTGRES_HOST_AUTH_METHOD=trust --env=POSTGRES_PASSWORD=e19936df92ee4c1d9fbf10ef139172e3 --env=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/14/bin --env=GOSU_VERSION=1.12 --env=LANG=en_US.utf8 --env=PG_MAJOR=14 --env=PG_VERSION=14.0-1.pgdg110+1 --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p 127.0.0.1:5432 --restart=no --runtime=runc -d ankane/pgvector:latest


screenshot of fail in catalog-api service I encountered: 
<img width="983" alt="Screenshot 2023-11-24 023231" src="https://github.com/dotnet/eShop/assets/107916479/dade7658-6d8e-49ef-88c3-76d40d4741d2">
then i did it in my databasee ide to the same pgsql instance, it gave me the same error
![Screenshot 2023-11-24 022259](https://github.com/dotnet/eShop/assets/107916479/8ce07f78-7e92-4092-9b17-7a80402e5cd1)


