### PR TITLE
chore: Add Coverlet for code coverage in unit test projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,5 +80,7 @@
     <PackageVersion Include="xunit" Version="2.5.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0-preview.1.23556.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/Basket.UnitTests/Basket.UnitTests.csproj
+++ b/tests/Basket.UnitTests/Basket.UnitTests.csproj
@@ -8,6 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" />

--- a/tests/Ordering.UnitTests/Ordering.UnitTests.csproj
+++ b/tests/Ordering.UnitTests/Ordering.UnitTests.csproj
@@ -8,6 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">


### PR DESCRIPTION
Coverlet can help those who want to contribute by adding tests, so that they can easily see which part of the codebase are not covered by tests.

Need to install the [Fine Code Coverage](https://marketplace.visualstudio.com/items?itemName=FortuneNgwenya.FineCodeCoverage2022) extension for Visual Studio 2022

The sample image below shows that the BasketService.UpdateBasket() method is not covered by any test:

![image](https://github.com/dotnet/eShop/assets/108422823/f4427822-96b2-485e-98fa-9e812bc41b6e)
