### PR TITLE
Upgrade to stable SK 1.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,8 +44,8 @@
     <!-- Xabaril packages -->
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="7.0.0" />
     <!-- AI -->
-    <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.9" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.0.0-rc1" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.12" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.0.1" />
     <!-- Open Telemetry -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />

--- a/src/WebApp/Components/Chatbot/Chatbot.razor
+++ b/src/WebApp/Components/Chatbot/Chatbot.razor
@@ -1,6 +1,7 @@
 ﻿@rendermode @(new InteractiveServerRenderMode(prerender: false))
 @using Microsoft.AspNetCore.Components.Authorization
-@using Microsoft.SemanticKernel.AI.ChatCompletion
+@using Microsoft.SemanticKernel
+@using Microsoft.SemanticKernel.ChatCompletion
 @using eShop.WebApp.Chatbot
 @inject IJSRuntime JS
 @inject NavigationManager Nav


### PR DESCRIPTION
After this, we should do a little refactoring to actually inject the Kernel via DI, e.g. in central configuration somewhere, we'd AddOpenAIChatCompletion to the service container and AddKernel, and then in the razor component we inject Kernel, rather than building one in ChatState.