### PR TITLE
refactor: avoid closure creation

### DIFF
--- a/src/IntegrationEventLogEF/Utilities/ResilientTransaction.cs
+++ b/src/IntegrationEventLogEF/Utilities/ResilientTransaction.cs
@@ -13,9 +13,9 @@ public class ResilientTransaction
         //Use of an EF Core resiliency strategy when using multiple DbContexts within an explicit BeginTransaction():
         //See: https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency
         var strategy = _context.Database.CreateExecutionStrategy();
-        await strategy.ExecuteAsync(async () =>
+        await strategy.ExecuteAsync((_context), async context =>
         {
-            await using var transaction = await _context.Database.BeginTransactionAsync();
+            await using var transaction = await context.Database.BeginTransactionAsync();
             await action();
             await transaction.CommitAsync();
         });

--- a/src/Ordering.API/Application/Behaviors/TransactionBehavior.cs
+++ b/src/Ordering.API/Application/Behaviors/TransactionBehavior.cs
@@ -31,11 +31,11 @@ public class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior<TReque
 
             var strategy = _dbContext.Database.CreateExecutionStrategy();
 
-            await strategy.ExecuteAsync(async () =>
+            await strategy.ExecuteAsync(_dbContext, async context =>
             {
                 Guid transactionId;
 
-                await using var transaction = await _dbContext.BeginTransactionAsync();
+                await using var transaction = await context.BeginTransactionAsync();
                 using (_logger.BeginScope(new List<KeyValuePair<string, object>> { new("TransactionContext", transaction.TransactionId) }))
                 {
                     _logger.LogInformation("Begin transaction {TransactionId} for {CommandName} ({@Command})", transaction.TransactionId, typeName, request);

--- a/src/Shared/MigrateDbContextExtensions.cs
+++ b/src/Shared/MigrateDbContextExtensions.cs
@@ -43,7 +43,8 @@ internal static class MigrateDbContextExtensions
 
             var strategy = context.Database.CreateExecutionStrategy();
 
-            await strategy.ExecuteAsync(() => InvokeSeeder(seeder, context, scopeServices));
+            await strategy.ExecuteAsync((seeder, context, scopeServices),
+                (state => InvokeSeeder(state.seeder, state.context, state.scopeServices)));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
refactor: avoid closure creation

The ```ExecutionStrategyExtensions.ExecuteAsync``` has an overload method to support passing the state, thereby updating the usage to avoid creating the closure to capture the reference.

Since this code example is part of the official documentation, so I think providing a refined code example would be beneficial.
[Official document link](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-resilient-entity-framework-core-sql-connections)