### PR TITLE
fix: Playwright end-to-end tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,11 +12,12 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        global-json-file: global.json
     - name: Install Aspire
       run: |
         dotnet workload update
         dotnet workload install aspire
+        dotnet dev-certs https --trust
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,13 +1,13 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main ]
+    branches: [ mxschmitt/fix-e2e-tests ]
   pull_request:
     branches: [ main ]
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,17 +10,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Install Aspire
+      run: |
+        dotnet workload update
+        dotnet workload install aspire
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: npx playwright install --with-deps chromium
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v4
-      if: always()
       env:
         USERNAME1: bob
         PASSWORD: Pass123$
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,13 +1,13 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ mxschmitt/fix-e2e-tests ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,14 +17,13 @@ jobs:
       run: |
         dotnet workload update
         dotnet workload install aspire
-        dotnet dev-certs https --trust
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps chromium
+      run: npx playwright install chromium
     - name: Run Playwright tests
       run: npx playwright test
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -488,4 +488,5 @@ $RECYCLE.BIN/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/playwright/.auth/
 /user.json

--- a/e2e/AddItemTest.spec.ts
+++ b/e2e/AddItemTest.spec.ts
@@ -1,21 +1,16 @@
 import { test, expect } from '@playwright/test';
 
 test('Add item to the cart', async ({ page }) => {
-   await page.goto('/');
-   
-   await expect(page.getByRole('heading', { name: 'Resources' })).toBeVisible();
+  await page.goto('/');
 
-   const page1Promise = page.waitForEvent('popup');
-   await page.getByRole('link', { name: 'https://localhost:7298' }).click();
-   const page1 = await page1Promise;
-   await expect(page1.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();  
-  await page1.getByRole('link', { name: 'Adventurer GPS Watch' }).click();
-  await page1.getByRole('button', { name: 'Add to shopping bag' }).click();
-  await page1.getByRole('link', { name: 'shopping bag' }).click();
-  await page1.getByRole('heading', { name: 'Shopping bag' }).click();  
- 
-  await page1.getByText('Total').nth(1).click();
-  await page1.getByLabel('product quantity').getByText('1');
-  
-  await expect.poll(() => page1.getByLabel('product quantity').count()).toBeGreaterThan(0);
+  await expect(page.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
+  await page.getByRole('link', { name: 'Adventurer GPS Watch' }).click();
+  await page.getByRole('button', { name: 'Add to shopping bag' }).click();
+  await page.getByRole('link', { name: 'shopping bag' }).click();
+  await page.getByRole('heading', { name: 'Shopping bag' }).click();
+
+  await page.getByText('Total').nth(1).click();
+  await page.getByLabel('product quantity').getByText('1');
+
+  await expect.poll(() => page.getByLabel('product quantity').count()).toBeGreaterThan(0);
 });

--- a/e2e/BrowseItemTest.spec.ts
+++ b/e2e/BrowseItemTest.spec.ts
@@ -2,16 +2,12 @@ import { test, expect } from '@playwright/test';
 
 test('Browse Items', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Resources' })).toBeVisible();
-  const page1Promise = page.waitForEvent('popup');
-  await page.getByRole('link', { name: 'https://localhost:7298' }).click();
-  const page1 = await page1Promise;
 
-  await expect(page1.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
 
-  await page1.getByRole('link', { name: 'Adventurer GPS Watch' }).click(); 
-  await page1.getByRole('heading', { name: 'Adventurer GPS Watch' }).click();
+  await page.getByRole('link', { name: 'Adventurer GPS Watch' }).click(); 
+  await page.getByRole('heading', { name: 'Adventurer GPS Watch' }).click();
   
   //Expect
-  await expect(page1.getByRole('heading', { name: 'Adventurer GPS Watch' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Adventurer GPS Watch' })).toBeVisible();
 });

--- a/e2e/RemoveItemTest.spec.ts
+++ b/e2e/RemoveItemTest.spec.ts
@@ -2,23 +2,20 @@ import { test, expect } from '@playwright/test';
 
 test('Remove item from cart', async ({ page }) => {
   await page.goto('/');
-  const page1Promise = page.waitForEvent('popup');
-  await page.getByRole('link', { name: 'https://localhost:7298' }).click();
-  const page1 = await page1Promise;
-  await expect(page1.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
   
-  await page1.getByRole('link', { name: 'Adventurer GPS Watch' }).click();
-  await expect(page1.getByRole('heading', { name: 'Adventurer GPS Watch' })).toBeVisible();
+  await page.getByRole('link', { name: 'Adventurer GPS Watch' }).click();
+  await expect(page.getByRole('heading', { name: 'Adventurer GPS Watch' })).toBeVisible();
   
-  await page1.getByRole('button', { name: 'Add to shopping bag' }).click();
-  await page1.getByRole('link', { name: 'shopping bag' }).click();
-  await expect(page1.getByRole('heading', { name: 'Shopping bag' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add to shopping bag' }).click();
+  await page.getByRole('link', { name: 'shopping bag' }).click();
+  await expect(page.getByRole('heading', { name: 'Shopping bag' })).toBeVisible();
 
-  await expect.poll(() => page1.getByLabel('product quantity').count()).toBeGreaterThan(0);
+  await expect.poll(() => page.getByLabel('product quantity').count()).toBeGreaterThan(0);
   
-  await page1.getByLabel('product quantity').fill('0');
+  await page.getByLabel('product quantity').fill('0');
 
-  await page1.getByRole('button', { name: 'Update' }).click();
+  await page.getByRole('button', { name: 'Update' }).click();
 
-  await expect(page1.getByText('Your shopping bag is empty')).toBeVisible();
+  await expect(page.getByText('Your shopping bag is empty')).toBeVisible();
 });

--- a/e2e/login.setup.ts
+++ b/e2e/login.setup.ts
@@ -1,20 +1,20 @@
 import { test as setup, expect } from '@playwright/test';
 import { STORAGE_STATE } from '../playwright.config';
+import { assert } from 'console';
+
+assert(process.env.USERNAME1, 'USERNAME1 is not set');
+assert(process.env.PASSWORD, 'PASSWORD is not set');
 
 setup('Login', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('heading', { name: 'Resources' }).click();
-    const page1Promise = page.waitForEvent('popup');
-    await page.getByRole('link', { name: 'https://localhost:7298' }).click();
-    const page1 = await page1Promise;
-    await expect(page1.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
-    
-    await page1.getByLabel('Sign in').click();
-    await expect(page1.getByRole('heading', { name: 'Login' })).toBeVisible();
-    
-    await page1.getByPlaceholder('Username').fill(process.env.USERNAME1);
-    await page1.getByPlaceholder('Password').fill(process.env.PASSWORD);
-    await page1.getByRole('button', { name: 'Login' }).click();
-    await expect(page1.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
-    await page.context().storageState({ path: STORAGE_STATE });
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
+
+  await page.getByLabel('Sign in').click();
+  await expect(page.getByRole('heading', { name: 'Login' })).toBeVisible();
+
+  await page.getByPlaceholder('Username').fill(process.env.USERNAME1!);
+  await page.getByPlaceholder('Password').fill(process.env.PASSWORD!);
+  await page.getByRole('button', { name: 'Login' }).click();
+  await expect(page.getByRole('heading', { name: 'Ready for a new adventure?' })).toBeVisible();
+  await page.context().storageState({ path: STORAGE_STATE });
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,8 +22,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'https://localhost:7298',
-    ignoreHTTPSErrors: true,
+    baseURL: 'http://localhost:5045',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -87,9 +86,8 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'dotnet run --project src/eShop.AppHost/eShop.AppHost.csproj',
-    url: 'https://localhost:7298',
+    url: 'http://localhost:5045',
     reuseExistingServer: !process.env.CI,
-    ignoreHTTPSErrors: true,
     stderr: 'pipe',
     stdout: 'pipe',
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,10 +22,12 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-     baseURL: 'https://localhost:19888',
+    baseURL: 'https://localhost:7298',
+    ignoreHTTPSErrors: true,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    ...devices['Desktop Chrome'],
   },
 
   /* Configure projects for major browsers */
@@ -44,7 +46,7 @@ export default defineConfig({
     },
     {
       name: 'e2e tests without logged in',
-      testMatch: ['**/BrowseItemTest.spec.ts']
+      testMatch: ['**/BrowseItemTest.spec.ts'],
     }
     // {
     //   name: 'chromium',
@@ -83,9 +85,12 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'dotnet run --project src/eShop.AppHost/eShop.AppHost.csproj',
+    url: 'https://localhost:7298',
+    reuseExistingServer: !process.env.CI,
+    ignoreHTTPSErrors: true,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  },
 });

--- a/src/Mobile.Bff.Shopping/Program.cs
+++ b/src/Mobile.Bff.Shopping/Program.cs
@@ -5,8 +5,6 @@ builder.AddApplicationServices();
 
 var app = builder.Build();
 
-app.UseHttpsRedirection();
-
 app.MapDefaultEndpoints();
 
 const string CatalogApiPrefix = "/api/v1/catalog/";

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -20,8 +20,6 @@ if (!app.Environment.IsDevelopment())
 
 app.UseAntiforgery();
 
-app.UseHttpsRedirection();
-
 app.UseStaticFiles();
 
 app.MapRazorComponents<App>().AddInteractiveServerRenderMode();

--- a/src/WebhookClient/Program.cs
+++ b/src/WebhookClient/Program.cs
@@ -20,8 +20,6 @@ if (!app.Environment.IsDevelopment())
 
 app.UseAntiforgery();
 
-app.UseHttpsRedirection();
-
 app.UseStaticFiles();
 
 app.MapRazorComponents<App>().AddInteractiveServerRenderMode();

--- a/src/eShop.AppHost/Program.cs
+++ b/src/eShop.AppHost/Program.cs
@@ -23,9 +23,9 @@ var openAi = builder.AddAzureOpenAI("openai");
 // Services
 var identityApi = builder.AddProject<Projects.Identity_API>("identity-api")
     .WithReference(identityDb)
-    .WithLaunchProfile("https");
+    .WithLaunchProfile("http");
 
-var idpHttps = identityApi.GetEndpoint("https");
+var idpHttps = identityApi.GetEndpoint("http");
 
 var basketApi = builder.AddProject<Projects.Basket_API>("basket-api")
     .WithReference(redis)
@@ -71,17 +71,17 @@ var webApp = builder.AddProject<Projects.WebApp>("webapp")
     .WithReference(rabbitMq)
     .WithReference(openAi, optional: true)
     .WithEnvironment("IdentityUrl", idpHttps)
-    .WithLaunchProfile("https");
+    .WithLaunchProfile("http");
 
 // Wire up the callback urls (self referencing)
-webApp.WithEnvironment("CallBackUrl", webApp.GetEndpoint("https"));
-webhooksClient.WithEnvironment("CallBackUrl", webhooksClient.GetEndpoint("https"));
+webApp.WithEnvironment("CallBackUrl", webApp.GetEndpoint("http"));
+webhooksClient.WithEnvironment("CallBackUrl", webhooksClient.GetEndpoint("http"));
 
 // Identity has a reference to all of the apps for callback urls, this is a cyclic reference
 identityApi.WithEnvironment("BasketApiClient", basketApi.GetEndpoint("http"))
            .WithEnvironment("OrderingApiClient", orderingApi.GetEndpoint("http"))
            .WithEnvironment("WebhooksApiClient", webHooksApi.GetEndpoint("http"))
-           .WithEnvironment("WebhooksWebClient", webhooksClient.GetEndpoint("https"))
-           .WithEnvironment("WebAppClient", webApp.GetEndpoint("https"));
+           .WithEnvironment("WebhooksWebClient", webhooksClient.GetEndpoint("http"))
+           .WithEnvironment("WebAppClient", webApp.GetEndpoint("http"));
 
 builder.Build().Run();


### PR DESCRIPTION
Motivation: We want to run Playwright tests on each CI run against a dev environment which gets spinned up on the GHA runner.

Blocker: I currently face this issue: 
<img width="896" alt="image" src="https://github.com/dotnet/eShop/assets/17984549/69cf8344-1fb1-4ce0-a3df-3ca4f70907bd">

which looks related to this:

```
@mxschmitt ➜ /workspaces/eShop (v-sruspasari/playwrightE2ETestCases) $ dotnet dev-certs https --trust
Trusting the HTTPS development certificate was requested. Trusting the certificate on Linux distributions automatically is not supported. For instructions on how to manually trust the certificate on your Linux distribution, go to https://aka.ms/dev-certs-trust
A valid HTTPS certificate is already present.
@mxschmitt ➜ /workspaces/eShop (mxschmitt/fix-e2e-tests) $
```

I'm not familiar with Aspire, maybe someone has an idea on how to fix it. Thanks!