### PR TITLE
Fix WebApps OpenAI usage

### DIFF
--- a/src/WebApp/Extensions/Extensions.cs
+++ b/src/WebApp/Extensions/Extensions.cs
@@ -103,6 +103,7 @@ public static class Extensions
 
         if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("openai")) && !string.IsNullOrWhiteSpace(deploymentName))
         {
+            builder.Services.AddKernel();
             builder.AddAzureOpenAI("openai");
             builder.Services.AddAzureOpenAIChatCompletion(deploymentName);
         }


### PR DESCRIPTION
The Kernel was never registered in DI, so it wasn't possible to use the AI services.