### PR TITLE
Using Semantic Kernel Memory

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,6 +124,13 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
+
+# SK experimental
+dotnet_diagnostic.SKEXP0001.severity = silent
+dotnet_diagnostic.SKEXP0010.severity = silent
+dotnet_diagnostic.SKEXP0020.severity = silent
+
+
 ###############################
 # VB Coding Conventions       #
 ###############################

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,9 @@
     <!-- Xabaril packages -->
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
     <!-- AI -->
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.6.3" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.7.1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.7.1-alpha" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Postgres" Version="1.7.1-alpha" />
     <!-- Open Telemetry -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />

--- a/src/Catalog.API/Catalog.API.csproj
+++ b/src/Catalog.API/Catalog.API.csproj
@@ -21,8 +21,12 @@
   <!-- AI -->
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.AI.OpenAI" />
+    <PackageReference Include="Aspire.Npgsql" />
     <PackageReference Include="Pgvector" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.SemanticKernel" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Postgres" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Catalog.API/Extensions/Extensions.cs
+++ b/src/Catalog.API/Extensions/Extensions.cs
@@ -1,16 +1,15 @@
 ﻿using eShop.Catalog.API.Services;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.Postgres;
+using Microsoft.SemanticKernel.Memory;
 
 public static class Extensions
 {
+    private const int VectorSize = 1536;
+
     public static void AddApplicationServices(this IHostApplicationBuilder builder)
     {
-        builder.AddNpgsqlDbContext<CatalogContext>("catalogdb", configureDbContextOptions: dbContextOptionsBuilder =>
-        {
-            dbContextOptionsBuilder.UseNpgsql(builder =>
-            {
-                builder.UseVector();
-            });
-        });
+        builder.AddNpgsqlDbContext<CatalogContext>("catalogdb");
 
         // REVIEW: This is done for development ease but shouldn't be here in production
         builder.Services.AddMigration<CatalogContext, CatalogContextSeed>();
@@ -29,10 +28,20 @@ public static class Extensions
 
         builder.Services.AddOptions<AIOptions>()
             .BindConfiguration("AI");
+        var openAIOptions = builder.Configuration.GetSection("AI").Get<AIOptions>()?.OpenAI;
 
-        if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("openai")))
+        if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("embedding")) && !string.IsNullOrEmpty(openAIOptions.EmbeddingName))
         {
-            builder.AddAzureOpenAIClient("openai");
+            builder.AddKeyedNpgsqlDataSource("catalogdb", null, builder => builder.UseVector());
+            builder.AddAzureOpenAIClient("embedding");
+            builder.Services.AddAzureOpenAITextEmbeddingGeneration(openAIOptions.EmbeddingName);
+            builder.Services.AddSingleton<IMemoryStore, PostgresMemoryStore>(provider =>
+            {
+                var dataSource = provider.GetRequiredKeyedService<NpgsqlDataSource>("catalogdb");
+
+                return new(dataSource, VectorSize);
+            });
+            builder.Services.AddSingleton<ISemanticTextMemory, SemanticTextMemory>();
         }
 
         builder.Services.AddSingleton<ICatalogAI, CatalogAI>();

--- a/src/Catalog.API/Infrastructure/EntityConfigurations/CatalogItemEntityTypeConfiguration.cs
+++ b/src/Catalog.API/Infrastructure/EntityConfigurations/CatalogItemEntityTypeConfiguration.cs
@@ -12,9 +12,6 @@ class CatalogItemEntityTypeConfiguration
 
         builder.Ignore(ci => ci.PictureUri);
 
-        builder.Property(ci => ci.Embedding)
-            .HasColumnType("vector(1536)");
-
         builder.HasOne(ci => ci.CatalogBrand)
             .WithMany();
 

--- a/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.Designer.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.Designer.cs
@@ -73,9 +73,6 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                     b.Property<string>("Description")
                         .HasColumnType("text");
 
-                    b.Property<Vector>("Embedding")
-                        .HasColumnType("vector(1536)");
-
                     b.Property<int>("MaxStockThreshold")
                         .HasColumnType("integer");
 

--- a/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/20231009153249_Initial.cs
@@ -64,7 +64,6 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                     AvailableStock = table.Column<int>(type: "integer", nullable: false),
                     RestockThreshold = table.Column<int>(type: "integer", nullable: false),
                     MaxStockThreshold = table.Column<int>(type: "integer", nullable: false),
-                    Embedding = table.Column<Vector>(type: "vector(1536)", nullable: true),
                     OnReorder = table.Column<bool>(type: "boolean", nullable: false)
                 },
                 constraints: table =>

--- a/src/Catalog.API/Infrastructure/Migrations/CatalogContextModelSnapshot.cs
+++ b/src/Catalog.API/Infrastructure/Migrations/CatalogContextModelSnapshot.cs
@@ -62,9 +62,6 @@ namespace eShop.Catalog.API.Infrastructure.Migrations
                     b.Property<string>("Description")
                         .HasColumnType("text");
 
-                    b.Property<Vector>("Embedding")
-                        .HasColumnType("vector(1536)");
-
                     b.Property<int>("MaxStockThreshold")
                         .HasColumnType("integer");
 

--- a/src/Catalog.API/Model/CatalogItem.cs
+++ b/src/Catalog.API/Model/CatalogItem.cs
@@ -37,10 +37,6 @@ public class CatalogItem
     // Maximum number of units that can be in-stock at any time (due to physicial/logistical constraints in warehouses)
     public int MaxStockThreshold { get; set; }
 
-    /// <summary>Optional embedding for the catalog item's description.</summary>
-    [JsonIgnore]
-    public Vector Embedding { get; set; }
-
     /// <summary>
     /// True if item is on reorder
     /// </summary>

--- a/src/Catalog.API/Services/CatalogAI.cs
+++ b/src/Catalog.API/Services/CatalogAI.cs
@@ -4,30 +4,13 @@ using Pgvector;
 
 namespace eShop.Catalog.API.Services;
 
-public sealed class CatalogAI(IOptions<AIOptions> options, ILogger<CatalogAI> logger, ISemanticTextMemory memory = null, OpenAIClient openAIClient = null) : ICatalogAI
+public sealed class CatalogAI(IOptions<AIOptions> options, ISemanticTextMemory memory = null, OpenAIClient openAIClient = null) : ICatalogAI
 {
     private const string MemoryCollection = "catalogMemory";
     private readonly string _aiEmbeddingModel = options.Value.OpenAI.EmbeddingName ?? "text-embedding-ada-002";
 
     /// <summary>Gets whether the AI system is enabled.</summary>
     public bool IsEnabled { get; } = openAIClient is not null;
-
-    /// <summary>Gets an embedding vector for the specified text.</summary>
-    public async ValueTask<Vector> GetEmbeddingAsync(string text)
-    {
-        if (!IsEnabled)
-        {
-            return null;
-        }
-
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            logger.LogInformation("Getting embedding for \"{text}\"", text);
-        }
-
-        EmbeddingsOptions options = new(_aiEmbeddingModel, [text]);
-        return new Vector((await openAIClient.GetEmbeddingsAsync(options)).Value.Data[0].Embedding);
-    }
 
     /// <summary>Saves the specified catalog item to memory.</summary>
     public ValueTask<string> SaveToMemoryAsync(CatalogItem item) =>

--- a/src/Catalog.API/Services/CatalogAI.cs
+++ b/src/Catalog.API/Services/CatalogAI.cs
@@ -1,35 +1,16 @@
 ﻿using Azure.AI.OpenAI;
+using Microsoft.SemanticKernel.Memory;
 using Pgvector;
 
 namespace eShop.Catalog.API.Services;
 
-public sealed class CatalogAI : ICatalogAI
+public sealed class CatalogAI(IOptions<AIOptions> options, ILogger<CatalogAI> logger, ISemanticTextMemory memory = null, OpenAIClient openAIClient = null) : ICatalogAI
 {
-    private readonly string _aiEmbeddingModel;
-    private readonly OpenAIClient _openAIClient;
-
-    /// <summary>The web host environment.</summary>
-    private readonly IWebHostEnvironment _environment;
-    /// <summary>Logger for use in AI operations.</summary>
-    private readonly ILogger _logger;
-
-    public CatalogAI(IOptions<AIOptions> options, IWebHostEnvironment environment, ILogger<CatalogAI> logger, OpenAIClient openAIClient = null)
-    {
-        var aiOptions = options.Value;
-        _openAIClient = openAIClient;
-        _aiEmbeddingModel = aiOptions.OpenAI.EmbeddingName ?? "text-embedding-ada-002";
-        IsEnabled = _openAIClient != null;
-        _environment = environment;
-        _logger = logger;
-
-        if (_logger.IsEnabled(LogLevel.Information))
-        {
-            _logger.LogInformation("Embedding model: \"{model}\"", _aiEmbeddingModel);
-        }
-    }
+    private const string MemoryCollection = "catalogMemory";
+    private readonly string _aiEmbeddingModel = options.Value.OpenAI.EmbeddingName ?? "text-embedding-ada-002";
 
     /// <summary>Gets whether the AI system is enabled.</summary>
-    public bool IsEnabled { get; }
+    public bool IsEnabled { get; } = openAIClient is not null;
 
     /// <summary>Gets an embedding vector for the specified text.</summary>
     public async ValueTask<Vector> GetEmbeddingAsync(string text)
@@ -39,17 +20,22 @@ public sealed class CatalogAI : ICatalogAI
             return null;
         }
 
-        if (_logger.IsEnabled(LogLevel.Information))
+        if (logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation("Getting embedding for \"{text}\"", text);
+            logger.LogInformation("Getting embedding for \"{text}\"", text);
         }
 
         EmbeddingsOptions options = new(_aiEmbeddingModel, [text]);
-        return new Vector((await _openAIClient.GetEmbeddingsAsync(options)).Value.Data[0].Embedding);
+        return new Vector((await openAIClient.GetEmbeddingsAsync(options)).Value.Data[0].Embedding);
     }
 
-    /// <summary>Gets an embedding vector for the specified catalog item.</summary>
-    public ValueTask<Vector> GetEmbeddingAsync(CatalogItem item) => IsEnabled ?
-        GetEmbeddingAsync($"{item.Name} {item.Description}") :
-        ValueTask.FromResult<Vector>(null);
+    /// <summary>Saves the specified catalog item to memory.</summary>
+    public ValueTask<string> SaveToMemoryAsync(CatalogItem item) =>
+        IsEnabled ?
+            new(memory.SaveInformationAsync(MemoryCollection, $"{item.Name} {item.Description}", item.Id.ToString()))
+            : new(string.Empty);
+
+    public IAsyncEnumerable<MemoryQueryResult> SearchMemoryAsync(string query, int pageSize) =>
+        IsEnabled ? memory.SearchAsync(MemoryCollection, query, pageSize) : throw new InvalidOperationException("Search can't be performed when AI is disabled");
+
 }

--- a/src/Catalog.API/Services/ICatalogAI.cs
+++ b/src/Catalog.API/Services/ICatalogAI.cs
@@ -1,4 +1,5 @@
-﻿using Pgvector;
+﻿using Microsoft.SemanticKernel.Memory;
+using Pgvector;
 
 namespace eShop.Catalog.API.Services;
 
@@ -6,5 +7,6 @@ public interface ICatalogAI
 {
     bool IsEnabled { get; }
     ValueTask<Vector> GetEmbeddingAsync(string text);
-    ValueTask<Vector> GetEmbeddingAsync(CatalogItem item);
+    ValueTask<string> SaveToMemoryAsync(CatalogItem item);
+    IAsyncEnumerable<MemoryQueryResult> SearchMemoryAsync(string query, int pageSize);
 }

--- a/src/Catalog.API/Services/ICatalogAI.cs
+++ b/src/Catalog.API/Services/ICatalogAI.cs
@@ -1,12 +1,10 @@
 ﻿using Microsoft.SemanticKernel.Memory;
-using Pgvector;
 
 namespace eShop.Catalog.API.Services;
 
 public interface ICatalogAI
 {
     bool IsEnabled { get; }
-    ValueTask<Vector> GetEmbeddingAsync(string text);
     ValueTask<string> SaveToMemoryAsync(CatalogItem item);
     IAsyncEnumerable<MemoryQueryResult> SearchMemoryAsync(string query, int pageSize);
 }

--- a/src/eShop.AppHost/Program.cs
+++ b/src/eShop.AppHost/Program.cs
@@ -67,7 +67,7 @@ var webApp = builder.AddProject<Projects.WebApp>("webapp", "http")
     .WithEnvironment("IdentityUrl", idpHttps);
 
 // set to true if you want to use OpenAI
-bool useOpenAI = true;
+bool useOpenAI = builder.Configuration.GetValue("EnableAI", false);
 if (useOpenAI)
 {
     const string chatAIName = "openai";


### PR DESCRIPTION
This moves from the custom solution for vector searching on Postgres, instead using the SK memory feature to do it. Added some new SK dependencies for the memory (and PG memory store), then removed the Embedding column from the current data model, as there is a new table with all that in it.

Refactored the seed logic to load the memory store using the previously generated embeddings.

Changed the CatalogAPI route to use the ISemanticTextMemory search feature to search memory, rather than the custom SQL query. This does mean we don't get distance surfaced, also, pagination is currently lost and SK memory doesn't support that (we could roll that ourselves if we want).

Included a fix so that AOAI can be deployed (issue #280), and pgadmin for easier debugging of the data in the database.

Fixes #282 