### PR TITLE
refactor: folder name inconsistency for models

### DIFF
--- a/src/Basket.API/Grpc/BasketService.cs
+++ b/src/Basket.API/Grpc/BasketService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using eShop.Basket.API.Repositories;
 using eShop.Basket.API.Extensions;
-using eShop.Basket.API.Model;
+using eShop.Basket.API.Models;
 
 namespace eShop.Basket.API.Grpc;
 

--- a/src/Basket.API/Models/BasketItem.cs
+++ b/src/Basket.API/Models/BasketItem.cs
@@ -1,4 +1,4 @@
-﻿namespace eShop.Basket.API.Model;
+﻿namespace eShop.Basket.API.Models;
 
 public class BasketItem : IValidatableObject
 {

--- a/src/Basket.API/Models/CustomerBasket.cs
+++ b/src/Basket.API/Models/CustomerBasket.cs
@@ -1,4 +1,4 @@
-﻿namespace eShop.Basket.API.Model;
+﻿namespace eShop.Basket.API.Models;
 
 public class CustomerBasket
 {

--- a/src/Basket.API/Repositories/IBasketRepository.cs
+++ b/src/Basket.API/Repositories/IBasketRepository.cs
@@ -1,4 +1,4 @@
-﻿using eShop.Basket.API.Model;
+﻿using eShop.Basket.API.Models;
 
 namespace eShop.Basket.API.Repositories;
 

--- a/src/Basket.API/Repositories/RedisBasketRepository.cs
+++ b/src/Basket.API/Repositories/RedisBasketRepository.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json.Serialization;
-using eShop.Basket.API.Model;
+using eShop.Basket.API.Models;
 
 namespace eShop.Basket.API.Repositories;
 

--- a/tests/Basket.UnitTests/BasketServiceTests.cs
+++ b/tests/Basket.UnitTests/BasketServiceTests.cs
@@ -1,10 +1,10 @@
 using System.Security.Claims;
 using eShop.Basket.API.Repositories;
 using eShop.Basket.API.Grpc;
-using eShop.Basket.API.Model;
+using eShop.Basket.API.Models;
 using eShop.Basket.UnitTests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
-using BasketItem = eShop.Basket.API.Model.BasketItem;
+using BasketItem = eShop.Basket.API.Models.BasketItem;
 
 namespace eShop.Basket.UnitTests;
 


### PR DESCRIPTION
refactor: folder name inconsistency for models

In this pull request, I have made a change to maintain consistency in folder names within the repository. I have renamed the folder 'Model' to 'Models' to align it with other projects. This improvement helps to make the code more readable and consistent with the conventions adopted in the project.