### PR TITLE
fixing Aspire Projects Resources in AppHost & Ordering.FunctionalTest (#237)

### DIFF
--- a/src/eShop.AppHost/eShop.AppHost.csproj
+++ b/src/eShop.AppHost/eShop.AppHost.csproj
@@ -18,16 +18,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Mobile.Bff.Shopping\Mobile.Bff.Shopping.csproj" />
-    <ProjectReference Include="..\Basket.API\Basket.API.csproj" />
-    <ProjectReference Include="..\Catalog.API\Catalog.API.csproj" />
-    <ProjectReference Include="..\Identity.API\Identity.API.csproj" />
-    <ProjectReference Include="..\Ordering.API\Ordering.API.csproj" />
-    <ProjectReference Include="..\OrderProcessor\OrderProcessor.csproj" />
-    <ProjectReference Include="..\PaymentProcessor\PaymentProcessor.csproj" />
-    <ProjectReference Include="..\Webhooks.API\Webhooks.API.csproj" />
-    <ProjectReference Include="..\WebApp\WebApp.csproj" />
-    <ProjectReference Include="..\WebhookClient\WebhookClient.csproj" />
+    <ProjectReference Include="..\Mobile.Bff.Shopping\Mobile.Bff.Shopping.csproj" IsAspireProjectResource="true"/>
+    <ProjectReference Include="..\Basket.API\Basket.API.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\Catalog.API\Catalog.API.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\Identity.API\Identity.API.csproj" IsAspireProjectResource="true"  />
+    <ProjectReference Include="..\Ordering.API\Ordering.API.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\OrderProcessor\OrderProcessor.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\PaymentProcessor\PaymentProcessor.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\Webhooks.API\Webhooks.API.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\WebApp\WebApp.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\WebhookClient\WebhookClient.csproj" IsAspireProjectResource="true" />
   </ItemGroup>
 
 </Project>

--- a/tests/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
+++ b/tests/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http.Client" />
     <PackageReference Include="Aspire.Hosting.AppHost" />
@@ -20,10 +20,10 @@
     </PackageReference>
     <PackageReference Include="xunit" />
   </ItemGroup>
- 
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ordering.API\Ordering.API.csproj" IsAspireProjectResource="false" />
-    <ProjectReference Include="..\..\src\Identity.API\Identity.API.csproj" />
+    <ProjectReference Include="..\..\src\Identity.API\Identity.API.csproj" IsAspireProjectResource="true" />
     <ProjectReference Include="..\..\src\Ordering.Domain\Ordering.Domain.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Ordering.Infrastructure\Ordering.Infrastructure.csproj" IsAspireProjectResource="false" />
   </ItemGroup>


### PR DESCRIPTION
For some users, when deleting the solution or deleting the obj and bin folders, there were problems with the AppHost and Ordering.FunctionalTest projects, where the references of the projects could not be found...

For example:
builder.AddProject<Projects.Identity_API>("identity-api")

this error show:
The type or namespace name 'Identity_API' does not exist in the namespace 'Projects' (are you missing an assembly reference?

for issue
#237 







