### PR TITLE
Adding small ChatState refactor in preparation for automated tests

### DIFF
--- a/src/WebApp/Components/Chatbot/ChatState.cs
+++ b/src/WebApp/Components/Chatbot/ChatState.cs
@@ -11,21 +11,19 @@ namespace eShop.WebApp.Chatbot;
 
 public class ChatState
 {
-    private readonly CatalogService _catalogService;
-    private readonly BasketState _basketState;
+    private readonly ICatalogService _catalogService;
+    private readonly IBasketState _basketState;
     private readonly ClaimsPrincipal _user;
-    private readonly NavigationManager _navigationManager;
     private readonly ILogger _logger;
     private readonly Kernel _kernel;
     private readonly IProductImageUrlProvider _productImages;
     private readonly OpenAIPromptExecutionSettings _aiSettings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
 
-    public ChatState(CatalogService catalogService, BasketState basketState, ClaimsPrincipal user, NavigationManager nav, IProductImageUrlProvider productImages, Kernel kernel, ILoggerFactory loggerFactory)
+    public ChatState(ICatalogService catalogService, IBasketState basketState, ClaimsPrincipal user, IProductImageUrlProvider productImages, Kernel kernel, ILoggerFactory loggerFactory)
     {
         _catalogService = catalogService;
         _basketState = basketState;
         _user = user;
-        _navigationManager = nav;
         _productImages = productImages;
         _logger = loggerFactory.CreateLogger(typeof(ChatState));
 

--- a/src/WebApp/Components/Chatbot/Chatbot.razor
+++ b/src/WebApp/Components/Chatbot/Chatbot.razor
@@ -58,7 +58,7 @@
         if (kernel is not null)
         {
             AuthenticationState auth = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-            chatState = new ChatState(CatalogService, BasketState, auth.User, Nav, ProductImages, kernel, LoggerFactory);
+            chatState = new ChatState(CatalogService, BasketState, auth.User, ProductImages, kernel, LoggerFactory);
         }
         else
         {

--- a/src/WebApp/Services/BasketState.cs
+++ b/src/WebApp/Services/BasketState.cs
@@ -10,7 +10,7 @@ public class BasketState(
     BasketService basketService,
     CatalogService catalogService,
     OrderingService orderingService,
-    AuthenticationStateProvider authenticationStateProvider)
+    AuthenticationStateProvider authenticationStateProvider) : IBasketState
 {
     private Task<IReadOnlyCollection<BasketItem>>? _cachedBasket;
     private HashSet<BasketStateChangedSubscription> _changeSubscriptions = new();

--- a/src/WebApp/Services/IBasketState.cs
+++ b/src/WebApp/Services/IBasketState.cs
@@ -1,0 +1,11 @@
+﻿using eShop.WebAppComponents.Catalog;
+
+namespace eShop.WebApp.Services
+{
+    public interface IBasketState
+    {
+        public Task<IReadOnlyCollection<BasketItem>> GetBasketItemsAsync();
+
+        public Task AddAsync(CatalogItem item);
+    }
+}

--- a/src/WebAppComponents/Services/CatalogService.cs
+++ b/src/WebAppComponents/Services/CatalogService.cs
@@ -4,7 +4,7 @@ using eShop.WebAppComponents.Catalog;
 
 namespace eShop.WebAppComponents.Services;
 
-public class CatalogService(HttpClient httpClient)
+public class CatalogService(HttpClient httpClient) : ICatalogService
 {
     private readonly string remoteServiceBaseUrl = "api/catalog/";
 

--- a/src/WebAppComponents/Services/ICatalogService.cs
+++ b/src/WebAppComponents/Services/ICatalogService.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using eShop.WebAppComponents.Catalog;
+
+namespace eShop.WebAppComponents.Services
+{
+    public interface ICatalogService
+    {
+        Task<CatalogItem?> GetCatalogItem(int id);
+        Task<CatalogResult> GetCatalogItems(int pageIndex, int pageSize, int? brand, int? type);
+        Task<List<CatalogItem>> GetCatalogItems(IEnumerable<int> ids);
+        Task<CatalogResult> GetCatalogItemsWithSemanticRelevance(int page, int take, string text);
+        Task<IEnumerable<CatalogBrand>> GetBrands();
+        Task<IEnumerable<CatalogItemType>> GetTypes();
+    }
+}


### PR DESCRIPTION
I am working in some automated tests for ChatState using xunit, and I found out a few things that could be improved to be able to do that:

- Removing unused nav element, updated blazor who initialized ChatState
- Added two interfaces for Basket and Catalog services so they can be mocked-up

