### PR TITLE
Refactored API versioning in service classes

### DIFF
--- a/src/ClientApp/Services/Catalog/CatalogService.cs
+++ b/src/ClientApp/Services/Catalog/CatalogService.cs
@@ -9,6 +9,8 @@ namespace eShop.ClientApp.Services.Catalog;
 public class CatalogService : ICatalogService
 {
     private const string ApiUrlBase = "api/catalog";
+    private const string ApiVersion = "api-version=1.0";
+    
     private readonly IFixUriService _fixUriService;
     private readonly IRequestProvider _requestProvider;
     private readonly ISettingsService _settingsService;
@@ -24,7 +26,7 @@ public class CatalogService : ICatalogService
     public async Task<IEnumerable<CatalogItem>> FilterAsync(int catalogBrandId, int catalogTypeId)
     {
         var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase,
-            $"{ApiUrlBase}/items/type/{catalogTypeId}/brand/{catalogBrandId}?PageSize=100&PageIndex=0&api-version=1.0");
+            $"{ApiUrlBase}/items/type/{catalogTypeId}/brand/{catalogBrandId}?PageSize=100&PageIndex=0&{ApiVersion}");
 
         var catalog = await _requestProvider.GetAsync<CatalogRoot>(uri).ConfigureAwait(false);
 
@@ -33,7 +35,7 @@ public class CatalogService : ICatalogService
 
     public async Task<IEnumerable<CatalogItem>> GetCatalogAsync()
     {
-        var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase, $"{ApiUrlBase}/items?PageSize=100&api-version=1.0");
+        var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase, $"{ApiUrlBase}/items?PageSize=100&{ApiVersion}");
 
         var catalog = await _requestProvider.GetAsync<CatalogRoot>(uri).ConfigureAwait(false);
 
@@ -49,7 +51,7 @@ public class CatalogService : ICatalogService
     public async Task<CatalogItem> GetCatalogItemAsync(int catalogItemId)
     {
         var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase,
-            $"{ApiUrlBase}/items/{catalogItemId}?api-version=1.0");
+            $"{ApiUrlBase}/items/{catalogItemId}?{ApiVersion}");
 
         var catalogItem = await _requestProvider.GetAsync<CatalogItem>(uri).ConfigureAwait(false);
 
@@ -64,7 +66,7 @@ public class CatalogService : ICatalogService
 
     public async Task<IEnumerable<CatalogBrand>> GetCatalogBrandAsync()
     {
-        var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase, $"{ApiUrlBase}/catalogbrands?api-version=1.0");
+        var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase, $"{ApiUrlBase}/catalogbrands?{ApiVersion}");
 
         var brands = await _requestProvider.GetAsync<IEnumerable<CatalogBrand>>(uri).ConfigureAwait(false);
 
@@ -73,7 +75,7 @@ public class CatalogService : ICatalogService
 
     public async Task<IEnumerable<CatalogType>> GetCatalogTypeAsync()
     {
-        var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase, $"{ApiUrlBase}/catalogtypes?api-version=1.0");
+        var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase, $"{ApiUrlBase}/catalogtypes?{ApiVersion}");
 
         var types = await _requestProvider.GetAsync<IEnumerable<CatalogType>>(uri).ConfigureAwait(false);
 

--- a/src/ClientApp/Services/FixUri/FixUriService.cs
+++ b/src/ClientApp/Services/FixUri/FixUriService.cs
@@ -9,6 +9,8 @@ namespace eShop.ClientApp.Services.FixUri;
 
 public class FixUriService : IFixUriService
 {
+    private const string ApiVersion = "api-version=1.0";
+    
     private readonly ISettingsService _settingsService;
 
     private readonly Regex IpRegex = new(@"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b");
@@ -31,7 +33,7 @@ public class FixUriService : IFixUriService
             {
                 foreach (var catalogItem in catalogItems)
                 {
-                    catalogItem.PictureUri = Path.Combine(_settingsService.GatewayCatalogEndpointBase, $"api/catalog/items/{catalogItem.Id}/pic?api-version=1.0");
+                    catalogItem.PictureUri = Path.Combine(_settingsService.GatewayCatalogEndpointBase, $"api/catalog/items/{catalogItem.Id}/pic?{ApiVersion}");
                 }
             }
         }

--- a/src/ClientApp/Services/Order/OrderService.cs
+++ b/src/ClientApp/Services/Order/OrderService.cs
@@ -11,6 +11,8 @@ namespace eShop.ClientApp.Services.Order;
 public class OrderService : IOrderService
 {
     private const string ApiUrlBase = "api/orders";
+    private const string ApiVersion = "api-version=1.0";
+    
     private readonly IIdentityService _identityService;
     private readonly IRequestProvider _requestProvider;
     private readonly ISettingsService _settingsService;
@@ -32,7 +34,7 @@ public class OrderService : IOrderService
             return;
         }
 
-        var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, ApiUrlBase)}?api-version=1.0";
+        var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, ApiUrlBase)}?{ApiVersion}";
 
         var success = await _requestProvider.PostAsync(uri, newOrder, authToken, "x-requestid").ConfigureAwait(false);
     }
@@ -46,7 +48,7 @@ public class OrderService : IOrderService
             return Enumerable.Empty<Models.Orders.Order>();
         }
 
-        var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, ApiUrlBase)}?api-version=1.0";
+        var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, ApiUrlBase)}?{ApiVersion}";
 
         var orders =
             await _requestProvider.GetAsync<IEnumerable<Models.Orders.Order>>(uri, authToken).ConfigureAwait(false);
@@ -65,7 +67,7 @@ public class OrderService : IOrderService
 
         try
         {
-            var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, $"{ApiUrlBase}/{orderId}")}?api-version=1.0";
+            var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, $"{ApiUrlBase}/{orderId}")}?{ApiVersion}";
 
             var order =
                 await _requestProvider.GetAsync<Models.Orders.Order>(uri, authToken).ConfigureAwait(false);
@@ -87,7 +89,7 @@ public class OrderService : IOrderService
             return false;
         }
 
-        var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, $"{ApiUrlBase}/cancel")}?api-version=1.0";
+        var uri = $"{UriHelper.CombineUri(_settingsService.GatewayOrdersEndpointBase, $"{ApiUrlBase}/cancel")}?{ApiVersion}";
 
         var cancelOrderCommand = new CancelOrderCommand(orderId);
 


### PR DESCRIPTION
The API version string has been refactored into a constant across multiple service classes. This change improves code maintainability by centralizing the API version value, making it easier to update in the future. The affected services include CatalogService, FixUriService, and OrderService.
