### PR TITLE
Updated service registration and network handling

### DIFF
--- a/src/ClientApp/Platforms/Android/AndroidManifest.xml
+++ b/src/ClientApp/Platforms/Android/AndroidManifest.xml
@@ -1,10 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:allowBackup="true" android:supportsRtl="true" android:usesCleartextTraffic="true">
+    <application android:allowBackup="true" android:supportsRtl="true" android:usesCleartextTraffic="true" android:networkSecurityConfig="@xml/network_security_config">
         <meta-data android:name="com.google.android.geo.API_KEY" android:value="YOUR_KEY_GOES_HERE"/>
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
     </application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <queries>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+    </queries>
 </manifest>

--- a/src/ClientApp/Platforms/Android/Resources/xml/network_security_config.xml
+++ b/src/ClientApp/Platforms/Android/Resources/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/src/ClientApp/Platforms/Android/WebAuthenticationCallbackActivity.cs
+++ b/src/ClientApp/Platforms/Android/WebAuthenticationCallbackActivity.cs
@@ -1,0 +1,14 @@
+﻿using Android.App;
+using Android.Content.PM;
+
+namespace eShop.ClientApp;
+
+[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop, Exported = true)]
+[IntentFilter(new[] { Android.Content.Intent.ActionView },
+    Categories = new[] { Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable },
+    DataScheme = "maui",
+    DataHost = "authcallback")]
+public class WebAuthenticationCallbackActivity : Microsoft.Maui.Authentication.WebAuthenticatorCallbackActivity
+{
+
+}

--- a/src/ClientApp/Services/Identity/IdentityService.cs
+++ b/src/ClientApp/Services/Identity/IdentityService.cs
@@ -10,11 +10,13 @@ public class IdentityService : IIdentityService
 {
     private readonly IBrowser _browser;
     private readonly ISettingsService _settingsService;
+    private readonly HttpMessageHandler _httpMessageHandler;
 
-    public IdentityService(IBrowser browser, ISettingsService settingsService)
+    public IdentityService(IBrowser browser, ISettingsService settingsService, HttpMessageHandler httpMessageHandler)
     {
         _browser = browser;
         _settingsService = settingsService;
+        _httpMessageHandler = httpMessageHandler;
     }
 
     public async Task<bool> SignInAsync()
@@ -138,14 +140,13 @@ public class IdentityService : IIdentityService
             Scope = "openid profile basket orders offline_access",
             RedirectUri = _settingsService.CallbackUri,
             PostLogoutRedirectUri = _settingsService.CallbackUri,
-            RefreshDiscoveryDocumentForLogin = false,
-            RefreshDiscoveryOnSignatureFailure = false,
             Browser = _browser,
         };
 
-        options.Policy.Discovery.RequireHttps = false;
-        options.Policy.Discovery.ValidateEndpoints = false;
-        options.Policy.Discovery.ValidateIssuerName = false;
+        if (_httpMessageHandler is not null)
+        {
+            options.BackchannelHandler = _httpMessageHandler;
+        }
         
         return new OidcClient(options);
     }

--- a/src/ClientApp/Services/RequestProvider/RequestProvider.cs
+++ b/src/ClientApp/Services/RequestProvider/RequestProvider.cs
@@ -7,19 +7,23 @@ using eShop.ClientApp.Exceptions;
 
 namespace eShop.ClientApp.Services.RequestProvider;
 
-public class RequestProvider : IRequestProvider
+public class RequestProvider(HttpMessageHandler _messageHandler) : IRequestProvider
 {
     private readonly Lazy<HttpClient> _httpClient =
         new(() =>
             {
-                var httpClient = new HttpClient();
+                var httpClient = _messageHandler is not null ? new HttpClient(_messageHandler) : new HttpClient();
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 return httpClient;
             },
             LazyThreadSafetyMode.ExecutionAndPublication);
 
     private readonly JsonSerializerOptions _jsonSerializerContext =
-        new() {PropertyNameCaseInsensitive = true, NumberHandling = JsonNumberHandling.AllowReadingFromString};
+        new()
+        {
+            PropertyNameCaseInsensitive = true, 
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+        };
 
     public async Task<TResult> GetAsync<TResult>(string uri, string token = "")
     {

--- a/src/ClientApp/ViewModels/SettingsViewModel.cs
+++ b/src/ClientApp/ViewModels/SettingsViewModel.cs
@@ -12,6 +12,9 @@ namespace eShop.ClientApp.ViewModels;
 
 public class SettingsViewModel : ViewModelBase
 {
+    //Needed if using Android Emulator Locally. See https://learn.microsoft.com/en-us/dotnet/maui/data-cloud/local-web-services?view=net-maui-8.0#android
+    private static string _baseAddress = DeviceInfo.Platform == DevicePlatform.Android ? "10.0.2.2" : "localhost";
+    
     private readonly IAppEnvironmentService _appEnvironmentService;
     private readonly ILocationService _locationService;
     private readonly ISettingsService _settingsService;
@@ -47,22 +50,22 @@ public class SettingsViewModel : ViewModelBase
         IdentityEndpoint =
             !string.IsNullOrEmpty(_settingsService.IdentityEndpointBase)
                 ? _settingsService.IdentityEndpointBase
-                : "https://localhost:5243";
+                : $"https://{_baseAddress}:5243";
 
         GatewayCatalogEndpoint =
             !string.IsNullOrEmpty(_settingsService.GatewayCatalogEndpointBase)
                 ? _settingsService.GatewayCatalogEndpointBase
-                : "http://localhost:11632";
+                : $"http://{_baseAddress}:11632";
 
         GatewayBasketEndpoint =
             !string.IsNullOrEmpty(_settingsService.GatewayBasketEndpointBase)
                 ? _settingsService.GatewayBasketEndpointBase
-                : "http://localhost:5221";
+                : $"http://{_baseAddress}:5221";
 
         GatewayOrdersEndpoint =
             !string.IsNullOrEmpty(_settingsService.GatewayOrdersEndpointBase)
                 ? _settingsService.GatewayOrdersEndpointBase
-                : "http://localhost:11632";
+                : $"http://{_baseAddress}:11632";
 
         ToggleMockServicesCommand = new RelayCommand(ToggleMockServices);
 

--- a/src/eShop.ServiceDefaults/AuthenticationExtensions.cs
+++ b/src/eShop.ServiceDefaults/AuthenticationExtensions.cs
@@ -38,6 +38,14 @@ public static class AuthenticationExtensions
             options.Authority = identityUrl;
             options.RequireHttpsMetadata = false;
             options.Audience = audience;
+            
+#if DEBUG
+            //Needed if using Android Emulator Locally. See https://learn.microsoft.com/en-us/dotnet/maui/data-cloud/local-web-services?view=net-maui-8.0#android
+            options.TokenValidationParameters.ValidIssuers = [identityUrl, "https://10.0.2.2:5243"];
+#else
+            options.TokenValidationParameters.ValidIssuers = [identityUrl];
+#endif
+            
             options.TokenValidationParameters.ValidateAudience = false;
         });
 


### PR DESCRIPTION
Significant changes include:
- Updated the way services are registered in MauiProgram.cs, with IRequestProvider and IIdentityService now using a factory method for instantiation.
- Added debug-specific HttpMessageHandler registration to ignore SSL certificate validation during development.
- Modified AndroidManifest.xml to include network security configuration and added corresponding XML file.
- Created new WebAuthenticationCallbackActivity class for Android platform.
- Adjusted IdentityService.cs and RequestProvider.cs to use an injected HttpMessageHandler, allowing more control over HTTP requests.
- Updated SettingsViewModel.cs to dynamically set base address depending on the device platform. This is particularly useful when using an Android emulator locally.
- Adjusted AuthenticationExtensions.cs to validate issuers based on whether the app is running in DEBUG mode or not.
