### PR TITLE
Update DuendeVersion to 7.0.6 in Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <AspireVersion>8.1.0</AspireVersion>
     <AspireUnstablePackagesVersion>8.0.0-preview.8.24258.2</AspireUnstablePackagesVersion>
     <GrpcVersion>2.64.0</GrpcVersion>
-    <DuendeVersion>7.0.5</DuendeVersion>
+    <DuendeVersion>7.0.6</DuendeVersion>
     <ApiVersioningVersion>8.1.0</ApiVersioningVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Duende version 7.0.5 has a vulnerability (https://github.com/advisories/GHSA-ff4q-64jc-gx98 ) which in turn breaks the build.

The vulnerability is remedied in version 7.0.6 and this PR updates the Duende version to 7.0.6.