### PR TITLE
Remove Dapper Package Reference

### DIFF
--- a/src/Ordering.API/GlobalUsings.cs
+++ b/src/Ordering.API/GlobalUsings.cs
@@ -3,7 +3,6 @@ global using Asp.Versioning.Conventions;
 global using System.Data.Common;
 global using Npgsql;
 global using System.Runtime.Serialization;
-global using Dapper;
 global using FluentValidation;
 global using MediatR;
 global using Microsoft.AspNetCore.Mvc;

--- a/src/Ordering.API/Ordering.API.csproj
+++ b/src/Ordering.API/Ordering.API.csproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" />
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="Dapper" />
     <PackageReference Include="FluentValidation.AspNetCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Dapper is not used in the Ordering.API anymore, so the dependency should be removed.