### PR TITLE
fix: Add max quantity limit for basket

### DIFF
--- a/src/Basket.API/Model/BasketItem.cs
+++ b/src/Basket.API/Model/BasketItem.cs
@@ -16,7 +16,12 @@ public class BasketItem : IValidatableObject
 
         if (Quantity < 1)
         {
-            results.Add(new ValidationResult("Invalid number of units", new[] { "Quantity" }));
+            results.Add(new ValidationResult($"Invalid number of units. Minimum value is 1.", new[] { "Quantity" }));
+        }
+
+        if (Quantity > 100)
+        {
+            results.Add(new ValidationResult($"Invalid number of units. Maximum value is 100.", new[] { "Quantity" }));
         }
 
         return results;


### PR DESCRIPTION
This pull request includes changes to the `Validate` method in the `BasketItem` class to improve validation logic for the `Quantity` property.

Validation logic improvements:

* [`src/Basket.API/Model/BasketItem.cs`](diffhunk://#diff-845968b9e96fcc10d3e2edbfef80c811cd40fafd8708edaab3b86d873efe9486L19-R24): Updated the validation logic in `Validate` method to include a check for the maximum quantity, ensuring the `Quantity` is between 1 and 100.