### PR TITLE
Upgrade Aspire.Hosting.AppHost to 8.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Version together with Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="$(AspireVersion)" />


### PR DESCRIPTION
To address the issue of "eShop.AppHost is a .NET Aspire AppHost project that needs a package reference to Aspire.Hosting.AppHo
st version 8.2.0 or above to work correctly" when first running the solution of eShop.AppHost.csproj, this PR bumps package of Aspire.Hosting.AppHost to 8.2.0.