### PR TITLE
Add OpenAPI metadata to Catalog API

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,0 +1,3 @@
+extends: spectral:oas
+rules:
+  info-contact: off

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -30,3 +30,11 @@ rules:
             - required: ["400"]
             - required: ["404"]
 
+  parameter-description:
+    description: All parameters should have a description
+    message: Parameter is missing a description.
+    severity: warn
+    given: $.paths.*.*.parameters[*]
+    then:
+      field: description
+      function: truthy

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,3 +1,32 @@
 extends: spectral:oas
 rules:
   info-contact: off
+  operation-operationId: off
+
+  success-response:
+    description: All operations should have a success response.
+    message: Operation is missing a success response.
+    severity: warn
+    given: $.paths.*.*.responses
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          anyOf:
+            - required: ["200"]
+            - required: ["201"]
+            - required: ["204"]
+
+  error-response:
+    description: All operations should have a error response.
+    message: Operation is missing a error response.
+    severity: warn
+    given: $.paths.*.*.responses
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          anyOf:
+            - required: ["400"]
+            - required: ["404"]
+

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,7 +1,6 @@
 extends: spectral:oas
 rules:
   info-contact: off
-  operation-operationId: off
 
   success-response:
     description: All operations should have a success response.

--- a/catalog.v1.json
+++ b/catalog.v1.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:52090"
+      "url": "http://localhost:62050"
     }
   ],
   "paths": {
@@ -60,9 +60,9 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -103,7 +103,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -138,6 +138,16 @@
         "responses": {
           "201": {
             "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -180,6 +190,16 @@
                   "items": {
                     "$ref": "#/components/schemas/CatalogItem"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -230,9 +250,9 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -328,6 +348,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -361,6 +391,71 @@
         "responses": {
           "404": {
             "description": "Not Found"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/bmp": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/tiff": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/wmf": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/jp2": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/svg+xml": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
           }
         }
       }
@@ -411,22 +506,22 @@
           }
         ],
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -499,6 +594,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -557,6 +662,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -604,6 +719,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -648,6 +773,16 @@
                       }
                     }
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -749,6 +884,41 @@
         },
         "nullable": true
       },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "PaginatedItemsOfCatalogItem": {
         "required": [
           "pageIndex",
@@ -775,6 +945,32 @@
             "items": {
               "$ref": "#/components/schemas/CatalogItem"
             },
+            "nullable": true
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
             "nullable": true
           }
         }

--- a/catalog.v1.json
+++ b/catalog.v1.json
@@ -7,15 +7,17 @@
   },
   "servers": [
     {
-      "url": "http://localhost:57688"
+      "url": "http://localhost:52090"
     }
   ],
   "paths": {
     "/api/catalog/items": {
       "get": {
         "tags": [
-          "Catalog"
+          "Items"
         ],
+        "summary": "List catalog items",
+        "description": "Get a paginated list of items in the catalog.",
         "parameters": [
           {
             "name": "PageSize",
@@ -69,8 +71,10 @@
       },
       "put": {
         "tags": [
-          "Catalog"
+          "Items"
         ],
+        "summary": "Create or replace a catalog item",
+        "description": "Create or replace a catalog item",
         "parameters": [
           {
             "name": "api-version",
@@ -110,6 +114,8 @@
         "tags": [
           "Catalog"
         ],
+        "summary": "Create a catalog item",
+        "description": "Create a new item in the catalog",
         "parameters": [
           {
             "name": "api-version",
@@ -139,8 +145,10 @@
     "/api/catalog/items/by": {
       "get": {
         "tags": [
-          "Catalog"
+          "Items"
         ],
+        "summary": "Batch get catalog items",
+        "description": "Get multiple items from the catalog",
         "parameters": [
           {
             "name": "ids",
@@ -182,8 +190,10 @@
     "/api/catalog/items/{id}": {
       "get": {
         "tags": [
-          "Catalog"
+          "Items"
         ],
+        "summary": "Get catalog item",
+        "description": "Get an item from the catalog",
         "parameters": [
           {
             "name": "id",
@@ -233,6 +243,8 @@
         "tags": [
           "Catalog"
         ],
+        "summary": "Delete catalog item",
+        "description": "Delete the specified catalog item",
         "parameters": [
           {
             "name": "id",
@@ -265,8 +277,10 @@
     "/api/catalog/items/by/{name}": {
       "get": {
         "tags": [
-          "Catalog"
+          "Items"
         ],
+        "summary": "Get catalog items by name",
+        "description": "Get a paginated list of catalog items with the specified name.",
         "parameters": [
           {
             "name": "PageSize",
@@ -318,14 +332,16 @@
         }
       }
     },
-    "/api/catalog/items/{catalogItemId}/pic": {
+    "/api/catalog/items/{id}/pic": {
       "get": {
         "tags": [
-          "Catalog"
+          "Items"
         ],
+        "summary": "Get catalog item picture",
+        "description": "Get the picture for a catalog item",
         "parameters": [
           {
-            "name": "catalogItemId",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -352,8 +368,10 @@
     "/api/catalog/items/withsemanticrelevance/{text}": {
       "get": {
         "tags": [
-          "Catalog"
+          "Search"
         ],
+        "summary": "Search catalog for relevant items",
+        "description": "Search the catalog for items related to the specified text",
         "parameters": [
           {
             "name": "PageSize",
@@ -376,6 +394,7 @@
           {
             "name": "text",
             "in": "path",
+            "description": "The text string to use when search for related items in the catalog",
             "required": true,
             "schema": {
               "minLength": 1,
@@ -418,8 +437,10 @@
     "/api/catalog/items/type/{typeId}/brand/{brandId}": {
       "get": {
         "tags": [
-          "Catalog"
+          "Types"
         ],
+        "summary": "Get catalog items by type and brand",
+        "description": "Get catalog items of the specified type and brand",
         "parameters": [
           {
             "name": "PageSize",
@@ -442,6 +463,7 @@
           {
             "name": "typeId",
             "in": "path",
+            "description": "The type of items to return",
             "required": true,
             "schema": {
               "type": "integer",
@@ -451,6 +473,7 @@
           {
             "name": "brandId",
             "in": "path",
+            "description": "The brand of items to return",
             "required": true,
             "schema": {
               "type": "integer",
@@ -483,8 +506,10 @@
     "/api/catalog/items/type/all/brand/{brandId}": {
       "get": {
         "tags": [
-          "Catalog"
+          "Brands"
         ],
+        "summary": "List catalog items by brand",
+        "description": "Get a list of catalog items for the specified brand",
         "parameters": [
           {
             "name": "PageSize",
@@ -539,8 +564,10 @@
     "/api/catalog/catalogtypes": {
       "get": {
         "tags": [
-          "Catalog"
+          "Types"
         ],
+        "summary": "List catalog item types",
+        "description": "Get a list of the types of catalog items",
         "parameters": [
           {
             "name": "api-version",
@@ -559,7 +586,20 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CatalogType2"
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "type": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
                   }
                 }
               }
@@ -571,8 +611,10 @@
     "/api/catalog/catalogbrands": {
       "get": {
         "tags": [
-          "Catalog"
+          "Brands"
         ],
+        "summary": "List catalog item brands",
+        "description": "Get a list of the brands of catalog items",
         "parameters": [
           {
             "name": "api-version",
@@ -591,7 +633,20 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CatalogBrand2"
+                    "required": [
+                      "brand"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "brand": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
                   }
                 }
               }
@@ -619,22 +674,6 @@
           }
         },
         "nullable": true
-      },
-      "CatalogBrand2": {
-        "required": [
-          "brand"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "brand": {
-            "type": "string",
-            "nullable": true
-          }
-        }
       },
       "CatalogItem": {
         "required": [
@@ -710,22 +749,6 @@
         },
         "nullable": true
       },
-      "CatalogType2": {
-        "required": [
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "type": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
       "PaginatedItemsOfCatalogItem": {
         "required": [
           "pageIndex",
@@ -760,7 +783,19 @@
   },
   "tags": [
     {
+      "name": "Items"
+    },
+    {
       "name": "Catalog"
+    },
+    {
+      "name": "Search"
+    },
+    {
+      "name": "Types"
+    },
+    {
+      "name": "Brands"
     }
   ]
 }

--- a/catalog.v1.json
+++ b/catalog.v1.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:50845"
+      "url": "http://localhost:52892"
     }
   ],
   "paths": {
@@ -18,6 +18,7 @@
         ],
         "summary": "List catalog items",
         "description": "Get a paginated list of items in the catalog.",
+        "operationId": "ListItems",
         "parameters": [
           {
             "name": "PageSize",
@@ -79,6 +80,7 @@
         ],
         "summary": "Create or replace a catalog item",
         "description": "Create or replace a catalog item",
+        "operationId": "UpdateItem",
         "parameters": [
           {
             "name": "api-version",
@@ -122,6 +124,7 @@
         ],
         "summary": "Create a catalog item",
         "description": "Create a new item in the catalog",
+        "operationId": "CreateItem",
         "parameters": [
           {
             "name": "api-version",
@@ -167,6 +170,7 @@
         ],
         "summary": "Batch get catalog items",
         "description": "Get multiple items from the catalog",
+        "operationId": "BatchGetItems",
         "parameters": [
           {
             "name": "ids",
@@ -225,6 +229,7 @@
         ],
         "summary": "Get catalog item",
         "description": "Get an item from the catalog",
+        "operationId": "GetItem",
         "parameters": [
           {
             "name": "id",
@@ -279,6 +284,7 @@
         ],
         "summary": "Delete catalog item",
         "description": "Delete the specified catalog item",
+        "operationId": "DeleteItem",
         "parameters": [
           {
             "name": "id",
@@ -318,6 +324,7 @@
         ],
         "summary": "Get catalog items by name",
         "description": "Get a paginated list of catalog items with the specified name.",
+        "operationId": "GetItemsByName",
         "parameters": [
           {
             "name": "PageSize",
@@ -391,6 +398,7 @@
         ],
         "summary": "Get catalog item picture",
         "description": "Get the picture for a catalog item",
+        "operationId": "GetItemPicture",
         "parameters": [
           {
             "name": "id",
@@ -492,6 +500,7 @@
         ],
         "summary": "Search catalog for relevant items",
         "description": "Search the catalog for items related to the specified text",
+        "operationId": "GetRelevantItems",
         "parameters": [
           {
             "name": "PageSize",
@@ -565,6 +574,7 @@
         ],
         "summary": "Get catalog items by type and brand",
         "description": "Get catalog items of the specified type and brand",
+        "operationId": "GetItemsByTypeAndBrand",
         "parameters": [
           {
             "name": "PageSize",
@@ -648,6 +658,7 @@
         ],
         "summary": "List catalog items by brand",
         "description": "Get a list of catalog items for the specified brand",
+        "operationId": "GetItemsByBrand",
         "parameters": [
           {
             "name": "PageSize",
@@ -721,6 +732,7 @@
         ],
         "summary": "List catalog item types",
         "description": "Get a list of the types of catalog items",
+        "operationId": "ListItemTypes",
         "parameters": [
           {
             "name": "api-version",
@@ -780,6 +792,7 @@
         ],
         "summary": "List catalog item brands",
         "description": "Get a list of the brands of catalog items",
+        "operationId": "ListItemBrands",
         "parameters": [
           {
             "name": "api-version",

--- a/catalog.v1.json
+++ b/catalog.v1.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:52892"
+      "url": "http://localhost:60903"
     }
   ],
   "paths": {
@@ -269,9 +269,9 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -938,41 +938,6 @@
           }
         },
         "nullable": true
-      },
-      "HttpValidationProblemDetails": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "nullable": true
-          },
-          "title": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "detail": {
-            "type": "string",
-            "nullable": true
-          },
-          "instance": {
-            "type": "string",
-            "nullable": true
-          },
-          "errors": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
       },
       "PaginatedItemsOfCatalogItem": {
         "required": [

--- a/catalog.v1.json
+++ b/catalog.v1.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:62050"
+      "url": "http://localhost:50845"
     }
   ],
   "paths": {
@@ -22,6 +22,7 @@
           {
             "name": "PageSize",
             "in": "query",
+            "description": "Number of items to return in a single page of results",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -31,6 +32,7 @@
           {
             "name": "PageIndex",
             "in": "query",
+            "description": "The index of the page of results to return",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -40,9 +42,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -79,9 +83,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -120,9 +126,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -163,6 +171,7 @@
           {
             "name": "ids",
             "in": "query",
+            "description": "List of ids for catalog items to return",
             "schema": {
               "type": "array",
               "items": {
@@ -174,9 +183,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -218,6 +229,7 @@
           {
             "name": "id",
             "in": "path",
+            "description": "The catalog item id",
             "required": true,
             "schema": {
               "type": "integer",
@@ -227,9 +239,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -269,6 +283,7 @@
           {
             "name": "id",
             "in": "path",
+            "description": "The id of the catalog item to delete",
             "required": true,
             "schema": {
               "type": "integer",
@@ -278,9 +293,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -305,6 +322,7 @@
           {
             "name": "PageSize",
             "in": "query",
+            "description": "Number of items to return in a single page of results",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -314,6 +332,7 @@
           {
             "name": "PageIndex",
             "in": "query",
+            "description": "The index of the page of results to return",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -323,6 +342,7 @@
           {
             "name": "name",
             "in": "path",
+            "description": "The name of the item to return",
             "required": true,
             "schema": {
               "minLength": 1,
@@ -332,9 +352,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -373,6 +395,7 @@
           {
             "name": "id",
             "in": "path",
+            "description": "The catalog item id",
             "required": true,
             "schema": {
               "type": "integer",
@@ -382,9 +405,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -471,6 +496,7 @@
           {
             "name": "PageSize",
             "in": "query",
+            "description": "Number of items to return in a single page of results",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -480,6 +506,7 @@
           {
             "name": "PageIndex",
             "in": "query",
+            "description": "The index of the page of results to return",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -499,9 +526,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -540,6 +569,7 @@
           {
             "name": "PageSize",
             "in": "query",
+            "description": "Number of items to return in a single page of results",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -549,6 +579,7 @@
           {
             "name": "PageIndex",
             "in": "query",
+            "description": "The index of the page of results to return",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -578,9 +609,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -619,6 +652,7 @@
           {
             "name": "PageSize",
             "in": "query",
+            "description": "Number of items to return in a single page of results",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -628,6 +662,7 @@
           {
             "name": "PageIndex",
             "in": "query",
+            "description": "The index of the page of results to return",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -637,6 +672,7 @@
           {
             "name": "brandId",
             "in": "path",
+            "description": "The brand of items to return",
             "required": true,
             "schema": {
               "type": "integer",
@@ -646,9 +682,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -687,9 +725,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],
@@ -744,9 +784,11 @@
           {
             "name": "api-version",
             "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "1.0"
             }
           }
         ],

--- a/catalog.v1.json
+++ b/catalog.v1.json
@@ -1,0 +1,766 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "eShop - Catalog HTTP API",
+    "description": "The Catalog Microservice HTTP API. This is a Data-Driven/CRUD microservice sample",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:57688"
+    }
+  ],
+  "paths": {
+    "/api/catalog/items": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    },
+    "/api/catalog/items/by": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/{id}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogItem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/catalog/items/by/{name}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/{catalogItemId}/pic": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "catalogItemId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/catalog/items/withsemanticrelevance/{text}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "text",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/type/{typeId}/brand/{brandId}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "typeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "brandId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/type/all/brand/{brandId}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "brandId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/catalogtypes": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogType2"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/catalogbrands": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogBrand2"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CatalogBrand": {
+        "required": [
+          "brand"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "brand": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "nullable": true
+      },
+      "CatalogBrand2": {
+        "required": [
+          "brand"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "brand": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "CatalogItem": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "price": {
+            "type": "number",
+            "format": "double"
+          },
+          "pictureFileName": {
+            "type": "string",
+            "nullable": true
+          },
+          "catalogTypeId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "catalogType": {
+            "$ref": "#/components/schemas/CatalogType"
+          },
+          "catalogBrandId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "catalogBrand": {
+            "$ref": "#/components/schemas/CatalogBrand"
+          },
+          "availableStock": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "restockThreshold": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStockThreshold": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "onReorder": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CatalogType": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "nullable": true
+      },
+      "CatalogType2": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "PaginatedItemsOfCatalogItem": {
+        "required": [
+          "pageIndex",
+          "pageSize",
+          "count",
+          "data"
+        ],
+        "type": "object",
+        "properties": {
+          "pageIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatalogItem"
+            },
+            "nullable": true
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Catalog"
+    }
+  ]
+}

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -106,7 +106,7 @@ public static class CatalogApi
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
     public static async Task<Ok<List<CatalogItem>>> GetItemsByIds(
         [AsParameters] CatalogServices services,
-        int[] ids)
+        [Description("List of ids for catalog items to return")] int[] ids)
     {
         var items = await services.Context.CatalogItems.Where(item => ids.Contains(item.Id)).ToListAsync();
         return TypedResults.Ok(items);
@@ -114,7 +114,7 @@ public static class CatalogApi
 
     public static async Task<Results<Ok<CatalogItem>, NotFound, ValidationProblem>> GetItemById(
         [AsParameters] CatalogServices services,
-        int id)
+        [Description("The catalog item id")] int id)
     {
         if (id <= 0)
         {
@@ -135,7 +135,7 @@ public static class CatalogApi
     public static async Task<Ok<PaginatedItems<CatalogItem>>> GetItemsByName(
         [AsParameters] PaginationRequest paginationRequest,
         [AsParameters] CatalogServices services,
-        string name)
+        [Description("The name of the item to return")] string name)
     {
         var pageSize = paginationRequest.PageSize;
         var pageIndex = paginationRequest.PageIndex;
@@ -156,7 +156,10 @@ public static class CatalogApi
     [ProducesResponseType<byte[]>(StatusCodes.Status200OK, "application/octet-stream", 
         [ "image/png", "image/gif", "image/jpeg", "image/bmp", "image/tiff",
           "image/wmf", "image/jp2", "image/svg+xml", "image/webp" ])]
-    public static async Task<Results<PhysicalFileHttpResult,NotFound>> GetItemPictureById(CatalogContext context, IWebHostEnvironment environment, int id)
+    public static async Task<Results<PhysicalFileHttpResult,NotFound>> GetItemPictureById(
+        CatalogContext context,
+        IWebHostEnvironment environment,
+        [Description("The catalog item id")] int id)
     {
         var item = await context.CatalogItems.FindAsync(id);
 
@@ -178,8 +181,7 @@ public static class CatalogApi
     public static async Task<Results<Ok<PaginatedItems<CatalogItem>>, RedirectToRouteHttpResult>> GetItemsBySemanticRelevance(
         [AsParameters] PaginationRequest paginationRequest,
         [AsParameters] CatalogServices services,
-        [Description("The text string to use when search for related items in the catalog")]
-        string text)
+        [Description("The text string to use when search for related items in the catalog")] string text)
     {
         var pageSize = paginationRequest.PageSize;
         var pageIndex = paginationRequest.PageIndex;
@@ -227,10 +229,8 @@ public static class CatalogApi
     public static async Task<Ok<PaginatedItems<CatalogItem>>> GetItemsByBrandAndTypeId(
         [AsParameters] PaginationRequest paginationRequest,
         [AsParameters] CatalogServices services,
-        [Description("The type of items to return")]
-        int typeId,
-        [Description("The brand of items to return")]
-        int? brandId)
+        [Description("The type of items to return")] int typeId,
+        [Description("The brand of items to return")] int? brandId)
     {
         var pageSize = paginationRequest.PageSize;
         var pageIndex = paginationRequest.PageIndex;
@@ -257,7 +257,7 @@ public static class CatalogApi
     public static async Task<Ok<PaginatedItems<CatalogItem>>> GetItemsByBrandId(
         [AsParameters] PaginationRequest paginationRequest,
         [AsParameters] CatalogServices services,
-        int? brandId)
+        [Description("The brand of items to return")] int? brandId)
     {
         var pageSize = paginationRequest.PageSize;
         var pageIndex = paginationRequest.PageIndex;
@@ -348,7 +348,7 @@ public static class CatalogApi
 
     public static async Task<Results<NoContent, NotFound>> DeleteItemById(
         [AsParameters] CatalogServices services,
-        int id)
+        [Description("The id of the catalog item to delete")] int id)
     {
         var item = services.Context.CatalogItems.SingleOrDefault(x => x.Id == id);
 

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -18,63 +18,76 @@ public static class CatalogApi
 
         // Routes for querying catalog items.
         api.MapGet("/items", GetAllItems)
+            .WithName("ListItems")
             .WithSummary("List catalog items")
             .WithDescription("Get a paginated list of items in the catalog.")
             .WithTags("Items");
         api.MapGet("/items/by", GetItemsByIds)
+            .WithName("BatchGetItems")
             .WithSummary("Batch get catalog items")
             .WithDescription("Get multiple items from the catalog")
             .WithTags("Items");
         api.MapGet("/items/{id:int}", GetItemById)
+            .WithName("GetItem")
             .WithSummary("Get catalog item")
             .WithDescription("Get an item from the catalog")
             .WithTags("Items");
         api.MapGet("/items/by/{name:minlength(1)}", GetItemsByName)
+            .WithName("GetItemsByName")
             .WithSummary("Get catalog items by name")
             .WithDescription("Get a paginated list of catalog items with the specified name.")
             .WithTags("Items");
         api.MapGet("/items/{id:int}/pic", GetItemPictureById)
+            .WithName("GetItemPicture")
             .WithSummary("Get catalog item picture")
             .WithDescription("Get the picture for a catalog item")
             .WithTags("Items");
 
         // Routes for resolving catalog items using AI.
         api.MapGet("/items/withsemanticrelevance/{text:minlength(1)}", GetItemsBySemanticRelevance)
+            .WithName("GetRelevantItems")
             .WithSummary("Search catalog for relevant items")
             .WithDescription("Search the catalog for items related to the specified text")
             .WithTags("Search");
 
         // Routes for resolving catalog items by type and brand.
         api.MapGet("/items/type/{typeId}/brand/{brandId?}", GetItemsByBrandAndTypeId)
+            .WithName("GetItemsByTypeAndBrand")
             .WithSummary("Get catalog items by type and brand")
             .WithDescription("Get catalog items of the specified type and brand")
             .WithTags("Types");
         api.MapGet("/items/type/all/brand/{brandId:int?}", GetItemsByBrandId)
+            .WithName("GetItemsByBrand")
             .WithSummary("List catalog items by brand")
             .WithDescription("Get a list of catalog items for the specified brand")
             .WithTags("Brands");
         api.MapGet("/catalogtypes",
             [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")] 
             async (CatalogContext context) => await context.CatalogTypes.OrderBy(x => x.Type).ToListAsync())
+            .WithName("ListItemTypes")
             .WithSummary("List catalog item types")
             .WithDescription("Get a list of the types of catalog items")
             .WithTags("Types");
         api.MapGet("/catalogbrands",
             [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
             async (CatalogContext context) => await context.CatalogBrands.OrderBy(x => x.Brand).ToListAsync())
+            .WithName("ListItemBrands")
             .WithSummary("List catalog item brands")
             .WithDescription("Get a list of the brands of catalog items")
             .WithTags("Brands");
 
         // Routes for modifying catalog items.
         api.MapPut("/items", UpdateItem)
+            .WithName("UpdateItem")
             .WithSummary("Create or replace a catalog item")
             .WithDescription("Create or replace a catalog item")
             .WithTags("Items");
         api.MapPost("/items", CreateItem)
+            .WithName("CreateItem")
             .WithSummary("Create a catalog item")
             .WithDescription("Create a new item in the catalog");
         api.MapDelete("/items/{id:int}", DeleteItemById)
+            .WithName("DeleteItem")
             .WithSummary("Delete catalog item")
             .WithDescription("Delete the specified catalog item");
 

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -1,11 +1,7 @@
 ﻿using System.ComponentModel;
-using System.Reflection;
-using Grpc.Core;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.VisualBasic;
 using Pgvector.EntityFrameworkCore;
 
 namespace eShop.Catalog.API;
@@ -62,7 +58,7 @@ public static class CatalogApi
             .WithDescription("Get a list of catalog items for the specified brand")
             .WithTags("Brands");
         api.MapGet("/catalogtypes",
-            [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")] 
+            [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
             async (CatalogContext context) => await context.CatalogTypes.OrderBy(x => x.Type).ToListAsync())
             .WithName("ListItemTypes")
             .WithSummary("List catalog item types")
@@ -94,7 +90,8 @@ public static class CatalogApi
         return app;
     }
 
-    static DefaultProblemDetailsFactory problemDetailsFactory = new DefaultProblemDetailsFactory(null);
+    static DefaultProblemDetailsFactory problemDetailsFactory =
+        new DefaultProblemDetailsFactory(Options.Create(new ApiBehaviorOptions()));
 
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
     public static async Task<Ok<PaginatedItems<CatalogItem>>> GetAllItems(
@@ -125,13 +122,18 @@ public static class CatalogApi
         return TypedResults.Ok(items);
     }
 
-    public static async Task<Results<Ok<CatalogItem>, NotFound, ValidationProblem>> GetItemById(
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
+    public static async Task<Results<Ok<CatalogItem>, NotFound, BadRequest<ProblemDetails>>> GetItemById(
+        HttpContext httpContext,
         [AsParameters] CatalogServices services,
         [Description("The catalog item id")] int id)
     {
         if (id <= 0)
         {
-            return TypedResults.ValidationProblem(null, "Id is not valid");
+            var problemDetails = problemDetailsFactory.CreateProblemDetails(httpContext,
+                detail: $"Id is not valid", statusCode: StatusCodes.Status400BadRequest);
+            httpContext.Response.ContentType = "application/problem+json";
+            return TypedResults.BadRequest(problemDetails);
         }
 
         var item = await services.Context.CatalogItems.Include(ci => ci.CatalogBrand).SingleOrDefaultAsync(ci => ci.Id == id);
@@ -166,7 +168,7 @@ public static class CatalogApi
         return TypedResults.Ok(new PaginatedItems<CatalogItem>(pageIndex, pageSize, totalItems, itemsOnPage));
     }
 
-    [ProducesResponseType<byte[]>(StatusCodes.Status200OK, "application/octet-stream", 
+    [ProducesResponseType<byte[]>(StatusCodes.Status200OK, "application/octet-stream",
         [ "image/png", "image/gif", "image/jpeg", "image/bmp", "image/tiff",
           "image/wmf", "image/jp2", "image/svg+xml", "image/webp" ])]
     public static async Task<Results<PhysicalFileHttpResult,NotFound>> GetItemPictureById(
@@ -293,6 +295,7 @@ public static class CatalogApi
         return TypedResults.Ok(new PaginatedItems<CatalogItem>(pageIndex, pageSize, totalItems, itemsOnPage));
     }
 
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound, "application/problem+json")]
     public static async Task<Results<Created, NotFound<ProblemDetails>>> UpdateItem(
         HttpContext httpContext,
         [AsParameters] CatalogServices services,
@@ -303,7 +306,8 @@ public static class CatalogApi
         if (catalogItem == null)
         {
             var problemDetails = problemDetailsFactory.CreateProblemDetails(httpContext,
-                detail: $"Item with id {productToUpdate.Id} not found.", statusCode: 404);
+                detail: $"Item with id {productToUpdate.Id} not found.", statusCode: StatusCodes.Status404NotFound);
+            httpContext.Response.ContentType = "application/problem+json";
             return TypedResults.NotFound(problemDetails);
         }
 

--- a/src/Catalog.API/Catalog.API.http
+++ b/src/Catalog.API/Catalog.API.http
@@ -1,6 +1,10 @@
 ﻿@Catalog.API_HostAddress = http://localhost:5222
 @ApiVersion = 1.0
 
+GET {{Catalog.API_HostAddress}}/openapi/v1.json
+
+###
+
 GET {{Catalog.API_HostAddress}}/api/catalog/items?api-version={{ApiVersion}}
 
 ###
@@ -8,3 +12,28 @@ GET {{Catalog.API_HostAddress}}/api/catalog/items?api-version={{ApiVersion}}
 GET {{Catalog.API_HostAddress}}/api/catalog/items/type/1/brand/2?api-version={{ApiVersion}}
 
 ###
+
+# A request with an unknown API version returns a 400 ProblemDetails response
+
+GET {{Catalog.API_HostAddress}}/api/catalog/items/463/pic?api-version=99
+
+###
+
+# A request with an unknown item id returns a 404 NotFound with empty response body
+
+GET {{Catalog.API_HostAddress}}/api/catalog/items/463/pic?api-version={{ApiVersion}}
+
+###
+
+PUT {{Catalog.API_HostAddress}}/api/catalog/items?api-version={{ApiVersion}}
+content-type: application/json
+
+{
+  "id": 999,
+  "name": "Item1",
+  "price": 100,
+  "description": "Description1",
+  "pictureFileName": "item1.png",
+  "catalogTypeId": 1,
+  "catalogBrandId": 2
+}

--- a/src/Catalog.API/Model/PaginationRequest.cs
+++ b/src/Catalog.API/Model/PaginationRequest.cs
@@ -1,3 +1,13 @@
-﻿namespace eShop.Catalog.API.Model;
+﻿using System.ComponentModel;
 
-public record PaginationRequest(int PageSize = 10, int PageIndex = 0);
+namespace eShop.Catalog.API.Model;
+
+public record PaginationRequest(
+    [property: Description("Number of items to return in a single page of results")]
+    [property: DefaultValue(10)]
+    int PageSize = 10,
+
+    [property: Description("The index of the page of results to return")]
+    [property: DefaultValue(0)]
+    int PageIndex = 0
+);

--- a/src/Catalog.API/Program.cs
+++ b/src/Catalog.API/Program.cs
@@ -14,6 +14,8 @@ var app = builder.Build();
 
 app.MapDefaultEndpoints();
 
+app.UseStatusCodePages();
+
 app.NewVersionedApi("Catalog")
    .MapCatalogApiV1();
 

--- a/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
@@ -64,6 +64,7 @@ public static partial class Extensions
                     options.ApplyAuthorizationChecks([.. scopes.Keys]);
                     options.ApplySecuritySchemeDefinitions();
                     options.ApplyOperationDeprecatedStatus();
+                    options.ApplyApiVersionDescription();
                 });
             }
         }

--- a/src/eShop.ServiceDefaults/OpenApiOptionsExtensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApiOptionsExtensions.cs
@@ -149,6 +149,22 @@ internal static class OpenApiOptionsExtensions
         return options;
     }
 
+    public static OpenApiOptions ApplyApiVersionDescription(this OpenApiOptions options)
+    {
+        options.AddOperationTransformer((operation, context, cancellationToken) =>
+        {
+            // Find parameter named "api-version" and add a description to it
+            var apiVersionParameter = operation.Parameters.FirstOrDefault(p => p.Name == "api-version");
+            if (apiVersionParameter is not null)
+            {
+                apiVersionParameter.Description = "The API version, in the format 'major.minor'.";
+                apiVersionParameter.Schema.Example = new OpenApiString("1.0");
+            }
+            return Task.CompletedTask;
+        });
+        return options;
+    }
+    
     private static IOpenApiAny? CreateOpenApiAnyFromObject(object value)
     {
         return value switch


### PR DESCRIPTION
This PR adds OpenAPI metadata to the Catalog API.

It includes the generated OpenAPI doc, starting from the first commit, so that you can easily see how the doc was changed/improved by the app code changes.

I also included a Spectral ruleset file that checks basic structural correctness and adds rules to verify that all operations have both success and error responses defined and all parameters have descriptions.

The motivation for this work was so we could use this in demos of the OpenAPI document generation feature in upcoming conferences.