### PR TITLE
Minor edit to constructor parameter usage

### DIFF
--- a/src/eShop.AppHost/Extensions.cs
+++ b/src/eShop.AppHost/Extensions.cs
@@ -40,7 +40,7 @@ internal static class Extensions
         const string openAIName = "openai";
         const string textEmbeddingAzureDeploymentName = "text-embedding-3-small"; // unique identifier for specific deployment within Azure OpenAI resource
         const string textEmbeddingModelName = textEmbeddingAzureDeployName; // actual OpenAI model used in deployment
-        const string chatModelAzureDeployName = "gpt-4o-mini";
+        const string chatModelAzureDeploymentName = "gpt-4o-mini";
         const string chatModelName = chatModelAzureDeployName;
 
         // to use an existing OpenAI resource, add the following to the AppHost user secrets:

--- a/src/eShop.AppHost/Extensions.cs
+++ b/src/eShop.AppHost/Extensions.cs
@@ -63,7 +63,7 @@ internal static class Extensions
             //   "Location": "<location>"
             // }
             openAI = builder.AddAzureOpenAI(openAIName)
-                .AddDeployment(new AzureOpenAIDeployment(chatModelAzureDeployName, chatModelName, "2024-07-18"))
+                .AddDeployment(new AzureOpenAIDeployment(chatModelAzureDeploymentName, chatModelName, "2024-07-18"))
                 .AddDeployment(new AzureOpenAIDeployment(textEmbeddingAzureDeployName, textEmbeddingModelName, "1", skuCapacity: 20)); // 20k tokens per minute are needed to seed the initial embeddings
         }
 

--- a/src/eShop.AppHost/Extensions.cs
+++ b/src/eShop.AppHost/Extensions.cs
@@ -38,7 +38,7 @@ internal static class Extensions
         IResourceBuilder<ProjectResource> webApp)
     {
         const string openAIName = "openai";
-        const string textEmbeddingAzureDeployName = "text-embedding-3-small"; // unique identifier for specific deployment within Azure OpenAI resource
+        const string textEmbeddingAzureDeploymentName = "text-embedding-3-small"; // unique identifier for specific deployment within Azure OpenAI resource
         const string textEmbeddingModelName = textEmbeddingAzureDeployName; // actual OpenAI model used in deployment
         const string chatModelAzureDeployName = "gpt-4o-mini";
         const string chatModelName = chatModelAzureDeployName;

--- a/src/eShop.AppHost/Extensions.cs
+++ b/src/eShop.AppHost/Extensions.cs
@@ -38,10 +38,10 @@ internal static class Extensions
         IResourceBuilder<ProjectResource> webApp)
     {
         const string openAIName = "openai";
-        const string textEmbeddingAzureDeploymentName = "text-embedding-3-small"; // unique identifier for specific deployment within Azure OpenAI resource
-        const string textEmbeddingModelName = textEmbeddingAzureDeployName; // actual OpenAI model used in deployment
-        const string chatModelAzureDeploymentName = "gpt-4o-mini";
-        const string chatModelName = chatModelAzureDeployName;
+        const string textEmbeddingModelName = "text-embedding-3-small"; // name of actual OpenAI model used in deployment 
+        const string textEmbeddingAzureDeploymentName = textEmbeddingModelName; // unique identifier for specific deployment within Azure OpenAI resource
+        const string chatModelName = "gpt-4o-mini";
+        const string chatModelAzureDeploymentName = chatModelName;
 
         // to use an existing OpenAI resource, add the following to the AppHost user secrets:
         // "ConnectionStrings": {

--- a/src/eShop.AppHost/Extensions.cs
+++ b/src/eShop.AppHost/Extensions.cs
@@ -38,8 +38,10 @@ internal static class Extensions
         IResourceBuilder<ProjectResource> webApp)
     {
         const string openAIName = "openai";
-        const string textEmbeddingModelName = "text-embedding-3-small";
-        const string chatModelName = "gpt-4o-mini";
+        const string textEmbeddingAzureDeployName = "text-embedding-3-small"; // unique identifier for specific deployment within Azure OpenAI resource
+        const string textEmbeddingModelName = textEmbeddingAzureDeployName; // actual OpenAI model used in deployment
+        const string chatModelAzureDeployName = "gpt-4o-mini";
+        const string chatModelName = chatModelAzureDeployName;
 
         // to use an existing OpenAI resource, add the following to the AppHost user secrets:
         // "ConnectionStrings": {
@@ -61,8 +63,8 @@ internal static class Extensions
             //   "Location": "<location>"
             // }
             openAI = builder.AddAzureOpenAI(openAIName)
-                .AddDeployment(new AzureOpenAIDeployment(chatModelName, "gpt-4o-mini", "2024-07-18"))
-                .AddDeployment(new AzureOpenAIDeployment(textEmbeddingModelName, "text-embedding-3-small", "1", skuCapacity: 20)); // 20k tokens per minute are needed to seed the initial embeddings
+                .AddDeployment(new AzureOpenAIDeployment(chatModelAzureDeployName, chatModelName, "2024-07-18"))
+                .AddDeployment(new AzureOpenAIDeployment(textEmbeddingAzureDeployName, textEmbeddingModelName, "1", skuCapacity: 20)); // 20k tokens per minute are needed to seed the initial embeddings
         }
 
         catalogApi

--- a/src/eShop.AppHost/Extensions.cs
+++ b/src/eShop.AppHost/Extensions.cs
@@ -64,7 +64,7 @@ internal static class Extensions
             // }
             openAI = builder.AddAzureOpenAI(openAIName)
                 .AddDeployment(new AzureOpenAIDeployment(chatModelAzureDeploymentName, chatModelName, "2024-07-18"))
-                .AddDeployment(new AzureOpenAIDeployment(textEmbeddingAzureDeployName, textEmbeddingModelName, "1", skuCapacity: 20)); // 20k tokens per minute are needed to seed the initial embeddings
+                .AddDeployment(new AzureOpenAIDeployment(textEmbeddingAzureDeploymentName, textEmbeddingModelName, "1", skuCapacity: 20)); // 20k tokens per minute are needed to seed the initial embeddings
         }
 
         catalogApi


### PR DESCRIPTION
Parameter names were hardcoded once, then used that same string value again. Seemed like a (very minor) oversight. I did a Perplexity search to find the difference between "name" and "modelName" parameters to the "AzureOpenAIDeployment" ctor, and added comments to clearify. (https://www.perplexity.ai/search/in-the-net-class-azureopenaide-Tl6V.J0QSpGunsDABqdvJQ)