### PR TITLE
Fix XamlC warnings in .NET MAUI app

### DIFF
--- a/src/ClientApp/ClientApp.csproj
+++ b/src/ClientApp/ClientApp.csproj
@@ -18,9 +18,9 @@
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
-    <MauiEnableXamlCBindingWithSourceCompilation>false</MauiEnableXamlCBindingWithSourceCompilation>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-		<NoWarn>$(NoWarn);XC0022;XC0023;XC0025;XC0103</NoWarn>
+    <NoWarn>$(NoWarn);XC0103</NoWarn>
 
     <!-- Display name -->
     <ApplicationTitle>AdventureWorks</ApplicationTitle>

--- a/src/ClientApp/Views/BasketView.xaml
+++ b/src/ClientApp/Views/BasketView.xaml
@@ -17,7 +17,7 @@
             Grid.Row="0"
             ItemsSource="{Binding BasketItems}"
             SelectionChangedCommand="{Binding AddCommand}"
-            SelectionChangedCommandParameter="{Binding SelectedItem, Source={RelativeSource Self}}">
+            SelectionChangedCommandParameter="{Binding SelectedItem, Source={RelativeSource Self}, x:DataType=CollectionView}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <templates:BasketItemTemplate />

--- a/src/ClientApp/Views/CatalogView.xaml
+++ b/src/ClientApp/Views/CatalogView.xaml
@@ -73,7 +73,7 @@
             Scrolled="Products_OnScrolled"
             SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
             SelectionChangedCommand="{Binding ViewCatalogItemCommand, Mode=OneTime}"
-            SelectionChangedCommandParameter="{Binding SelectedItem, Source={RelativeSource Self}}"
+            SelectionChangedCommandParameter="{Binding SelectedItem, Source={RelativeSource Self}, x:DataType=CollectionView}"
             SelectionMode="Single"
             VerticalScrollBarVisibility="Never">
             <CollectionView.Header>
@@ -161,13 +161,13 @@
                                     <DataTemplate x:DataType="viewmodels:CatalogBrandSelectionViewModel">
                                         <Button
                                             Margin="4"
-                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:CatalogViewModel}}, Path=SelectCatalogBrandCommand}"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:CatalogViewModel}}, Path=SelectCatalogBrandCommand, x:DataType=viewmodels:CatalogViewModel}"
                                             CommandParameter="{Binding Value}"
                                             Style="{StaticResource TransparentButtonStyle}"
                                             Text="{Binding Value.Brand, Mode=OneTime}">
                                             <Button.Triggers>
                                                 <DataTrigger
-                                                    Binding="{Binding Selected}"
+                                                    Binding="{Binding Selected, x:DataType=viewmodels:CatalogBrandSelectionViewModel}"
                                                     TargetType="Button"
                                                     Value="True">
                                                     <Setter Property="TextColor" Value="{StaticResource HighlightColor}" />
@@ -191,13 +191,13 @@
                                     <DataTemplate x:DataType="viewmodels:CatalogTypeSelectionViewModel">
                                         <Button
                                             Margin="4"
-                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:CatalogViewModel}}, Path=SelectCatalogTypeCommand}"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:CatalogViewModel}}, Path=SelectCatalogTypeCommand, x:DataType=viewmodels:CatalogViewModel}"
                                             CommandParameter="{Binding Value}"
                                             Style="{StaticResource TransparentButtonStyle}"
                                             Text="{Binding Value.Type, Mode=OneTime}">
                                             <Button.Triggers>
                                                 <DataTrigger
-                                                    Binding="{Binding Selected}"
+                                                    Binding="{Binding Selected, x:DataType=viewmodels:CatalogTypeSelectionViewModel}"
                                                     TargetType="Button"
                                                     Value="True">
                                                     <Setter Property="TextColor" Value="{StaticResource HighlightColor}" />

--- a/src/ClientApp/Views/FiltersView.xaml
+++ b/src/ClientApp/Views/FiltersView.xaml
@@ -28,14 +28,14 @@
                 <Picker
                     Title="BRAND"
                     ios:Picker.UpdateMode="WhenFinished"
-                    ItemDisplayBinding="{Binding Brand}"
+                    ItemDisplayBinding="{Binding Value.Brand, x:DataType=viewmodels:CatalogBrandSelectionViewModel}"
                     ItemsSource="{Binding Brands}"
                     SelectedItem="{Binding SelectedBrand, Mode=TwoWay}" />
                 <!--  TYPE  -->
                 <Picker
                     Title="TYPE"
                     ios:Picker.UpdateMode="WhenFinished"
-                    ItemDisplayBinding="{Binding Type}"
+                    ItemDisplayBinding="{Binding Value.Type, x:DataType=viewmodels:CatalogTypeSelectionViewModel}"
                     ItemsSource="{Binding Types}"
                     SelectedItem="{Binding SelectedType, Mode=TwoWay}" />
                 <Button Command="{Binding FilterCommand}" Text="Apply">

--- a/src/ClientApp/Views/ProfileView.xaml
+++ b/src/ClientApp/Views/ProfileView.xaml
@@ -40,7 +40,7 @@
             ItemsSource="{Binding Orders}"
             SelectedItem="{Binding SelectedOrder, Mode=TwoWay}"
             SelectionChangedCommand="{Binding OrderDetailCommand}"
-            SelectionChangedCommandParameter="{Binding SelectedItem, Source={RelativeSource Self}}"
+            SelectionChangedCommandParameter="{Binding SelectedItem, Source={RelativeSource Self}, x:DataType=CollectionView}"
             SelectionMode="Single">
             <CollectionView.ItemTemplate>
                 <DataTemplate>

--- a/src/ClientApp/Views/Templates/BasketItemTemplate.xaml
+++ b/src/ClientApp/Views/Templates/BasketItemTemplate.xaml
@@ -35,7 +35,7 @@
         <SwipeItems>
             <SwipeItem
                 BackgroundColor="Red"
-                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:BasketViewModel}}, Path=DeleteCommand}"
+                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:BasketViewModel}}, Path=DeleteCommand, x:DataType=vm:BasketViewModel}"
                 CommandParameter="{Binding}"
                 Text="Delete" />
         </SwipeItems>
@@ -101,7 +101,7 @@
             <!--  DELETE BUTTON IF ON DESKTOP  -->
             <Button
                 Grid.Row="2"
-                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:BasketViewModel}}, Path=DeleteCommand}"
+                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:BasketViewModel}}, Path=DeleteCommand, x:DataType=vm:BasketViewModel}"
                 CommandParameter="{Binding}"
                 HorizontalOptions="Start"
                 IsVisible="{OnIdiom False,


### PR DESCRIPTION
This PR fixes XamlC warnings in the .NET MAUI app that are related to @jamesmontemagno's upgrade to .NET 9.

The changes are straightforward. It was only necessary to add the missing `x:DataType` attribute to the XAML files and reenable the warnings. Adding the annotations revealed that the `FiltersView.xaml` bindings were incorrect (even though this make little impact since as far as I can tell it isn't used currently).

This is a prerequisite to making this app work with NativeAOT. It will be still necessary to switch to source-generated JSON serialization and update the CommunityToolkit once it supports .NET 9 and NativeAOT.