### PR TITLE
Remove Aspire workload references in README and CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,10 +23,6 @@ jobs:
     - uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
-    - name: Install Aspire
-      run: |
-        dotnet workload update
-        dotnet workload install aspire
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -23,10 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup .NET (global.json)
         uses: actions/setup-dotnet@v3
-      - name: Update Workloads
-        run: dotnet workload update
-      - name: Install Workloads
-        run: dotnet workload install aspire
       - name: Build 
         run: dotnet build eShop.Web.slnf
       - name: Test

--- a/README.md
+++ b/README.md
@@ -35,13 +35,7 @@ Or
 - From Dev Home go to `Machine Configuration -> Clone repositories`. Enter the URL for this repository. In the confirmation screen look for the section `Configuration File Detected` and click `Run File`.
 
 #### Mac, Linux, & Windows without Visual Studio
-- Install the latest [.NET 9 RC 1 SDK](https://dot.net/download?cid=eshop)
-- Install the [.NET Aspire workload](https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling?tabs=dotnet-cli%2Cunix#install-net-aspire) with the following commands:
-```powershell
-dotnet workload update
-dotnet workload install aspire
-dotnet restore eShop.Web.slnf
-```
+- Install the latest [.NET 9 RC 2 SDK](https://dot.net/download?cid=eshop)
 
 Or
 


### PR DESCRIPTION
We don't need the workload anymore now that we are on Aspire 9.