### PR TITLE
Update Scalar API reference config to avoid loading external assets

### DIFF
--- a/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
@@ -27,8 +27,6 @@ public static partial class Extensions
         {
             app.MapScalarApiReference(options =>
             {
-                // Empty CDN url to support loading JavaScript assets from NuGet package
-                options.CdnUrl = string.Empty;
                 // Disable default fonts to avoid download unnecessary fonts
                 options.DefaultFonts = false;
             });

--- a/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
@@ -1,5 +1,4 @@
 ﻿using Asp.Versioning;
-using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -26,7 +25,13 @@ public static partial class Extensions
 
         if (app.Environment.IsDevelopment())
         {
-            app.MapScalarApiReference();
+            app.MapScalarApiReference(options =>
+            {
+                // Empty CDN url to support loading JavaScript assets from NuGet package
+                options.CdnUrl = string.Empty;
+                // Disable default fonts to avoid download unnecessary fonts
+                options.DefaultFonts = false;
+            });
             app.MapGet("/", () => Results.Redirect("/scalar/v1")).ExcludeFromDescription();
         }
 
@@ -64,6 +69,13 @@ public static partial class Extensions
                     options.ApplyAuthorizationChecks([.. scopes.Keys]);
                     options.ApplySecuritySchemeDefinitions();
                     options.ApplyOperationDeprecatedStatus();
+                    // Clear out the default servers so we can fallback to
+                    // whatever ports have been allocated for the service by Aspire
+                    options.AddDocumentTransformer((document, context, cancellationToken) =>
+                    {
+                        document.Servers = [];
+                        return Task.CompletedTask;
+                    });
                 });
             }
         }


### PR DESCRIPTION
Use new options in the Scalar API reference to avoid loading external fonts and to fetch the `scalar.js` dependency from the local NuGet package instead of a public CDN.