### PR TITLE
Fix validation for quantity in BasketItem.cs

### DIFF
--- a/src/Basket.API/Model/BasketItem.cs
+++ b/src/Basket.API/Model/BasketItem.cs
@@ -19,6 +19,11 @@ public class BasketItem : IValidatableObject
             results.Add(new ValidationResult("Invalid number of units", new[] { "Quantity" }));
         }
 
+        if (Quantity > 100)
+        {
+            results.Add(new ValidationResult("Invalid number of units", new[] { "Quantity" }));
+        }
+
         return results;
     }
 }


### PR DESCRIPTION
This pull request includes a small change to the `Validate` method in the `BasketItem` class. The change adds a validation rule to ensure that the `Quantity` does not exceed 100 units.

* [`src/Basket.API/Model/BasketItem.cs`](diffhunk://#diff-845968b9e96fcc10d3e2edbfef80c811cd40fafd8708edaab3b86d873efe9486R22-R26): Added a validation rule to check if `Quantity` is greater than 100 and return an appropriate validation result.