### PR TITLE
Update package versions across multiple projects - cient apps

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <AspireVersion>9.0.0</AspireVersion>
     <AspireUnstablePackagesVersion>9.0.0-preview.5.24551.3</AspireUnstablePackagesVersion>
     <GrpcVersion>2.67.0-pre1</GrpcVersion>
-    <DuendeVersion>7.0.6</DuendeVersion>
+    <DuendeVersion>7.0.8</DuendeVersion>
     <ApiVersioningVersion>8.1.0</ApiVersioningVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -40,12 +40,12 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(AspnetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="$(AspnetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0-preview.8.24460.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
     <!-- Version together with EF -->
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0-rc.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0-rc.2.24474.1" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="Pgvector" Version="0.3.0" />
     <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.2.1" />
@@ -87,12 +87,12 @@
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
-    <PackageVersion Include="Polly.Core" Version="8.4.2" />
+    <PackageVersion Include="Polly.Core" Version="8.5.0" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
     <PackageVersion Include="IdentityModel" Version="7.0.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.34"/>
+    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.36"/>
   </ItemGroup>
 </Project>

--- a/src/ClientApp/ClientApp.csproj
+++ b/src/ClientApp/ClientApp.csproj
@@ -61,19 +61,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.28.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.28.3" />
     <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
     <PackageReference Include="Grpc.Tools" Version="2.67.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.*-*" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
 
-    <PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
+    <PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
     <PackageReference Include="IdentityModel" Version="7.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
   </ItemGroup>

--- a/src/HybridApp/HybridApp.csproj
+++ b/src/HybridApp/HybridApp.csproj
@@ -60,11 +60,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.0-rc.2.24503.2" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0-rc.2.24503.2" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0-rc.2.24503.2" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0-rc.2.24473.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0-rc.2.24473.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/ClientApp.UnitTests/ClientApp.UnitTests.csproj
+++ b/tests/ClientApp.UnitTests/ClientApp.UnitTests.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0-rc.2.24503.2" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     
@@ -22,9 +22,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update package versions across multiple projects

* 🔄 Updated `DuendeVersion` to `7.0.8` in `Directory.Packages.props`
* 🔄 Updated `MSTest.TestAdapter` to `3.6.3` and `MSTest.TestFramework` to `3.6.3` in `Directory.Packages.props` and `ClientApp.UnitTests.csproj`
* 🔄 Updated `NSubstitute` to `5.3.0` in `Directory.Packages.props`
* 🔄 Updated `Polly.Core` to `8.5.0` in `Directory.Packages.props`
* 🔄 Updated `Scalar.AspNetCore` to `1.2.36` in `Directory.Packages.props`
* 🔄 Updated `Google.Protobuf` to `3.28.3` in `ClientApp.csproj`
* 🔄 Updated `Microsoft.Maui` packages to `9.0.0` in `ClientApp.csproj`, `HybridApp.csproj`, and `ClientApp.UnitTests.csproj`
* 🔄 Updated `CommunityToolkit.Maui` to `9.1.1` in `ClientApp.csproj`
* 🔄 Updated `Microsoft.Extensions` packages to `9.0.0` in `HybridApp.csproj`

This commit ensures all projects are using the latest stable versions of their dependencies.

#### PR Classification
Dependency updates to ensure compatibility and stability.

#### PR Summary
This pull request updates various package dependencies to their latest versions.
- `Directory.Packages.props`: Updated versions for `DuendeVersion`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `NSubstitute`, `Polly.Core`, and `Scalar.AspNetCore`.
- `ClientApp.csproj`: Updated versions for `Google.Protobuf`, `Microsoft.Maui.Controls`, `Microsoft.Maui.Controls.Compatibility`, `Microsoft.Maui.Controls.Maps`, `Microsoft.Extensions.Logging.Debug`, and `CommunityToolkit.Maui`.
- `HybridApp.csproj`: Updated versions for `Microsoft.AspNetCore.Components.WebView.Maui`, `Microsoft.Maui.Controls`, `Microsoft.Maui.Controls.Compatibility`, `Microsoft.Extensions.Http`, and `Microsoft.Extensions.Logging.Debug`.
- `ClientApp.UnitTests.csproj`: Updated versions for `Microsoft.Maui.Controls`, `Microsoft.Maui.Controls.Compatibility`, `Microsoft.Maui.Controls.Maps`, `MSTest.TestAdapter`, and `MSTest.TestFramework`.
