### PR TITLE
9.0 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspnetVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(AspnetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0-preview.8.24460.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.2" />
     <!-- Version together with EF -->
@@ -56,10 +56,10 @@
     <!-- Xabaril packages -->
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
     <!-- AI -->
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.0.0-preview.9.24507.7" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.0-preview.9.24507.7" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.0.0-preview.9.24507.7" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Ollama" Version="9.0.0-preview.9.24507.7" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.0.0-preview.9.24556.5" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.0.0-preview.9.24556.5" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.0.0-preview.9.24556.5" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Ollama" Version="9.0.0-preview.9.24556.5" />
     <!-- Open Telemetry -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or
 - From Dev Home go to `Machine Configuration -> Clone repositories`. Enter the URL for this repository. In the confirmation screen look for the section `Configuration File Detected` and click `Run File`.
 
 #### Mac, Linux, & Windows without Visual Studio
-- Install the latest [.NET 9 RC 2 SDK](https://dot.net/download?cid=eshop)
+- Install the latest [.NET 9 SDK](https://dot.net/download?cid=eshop)
 
 Or
 

--- a/src/Catalog.API/Services/CatalogAI.cs
+++ b/src/Catalog.API/Services/CatalogAI.cs
@@ -58,7 +58,7 @@ public sealed class CatalogAI : ICatalogAI
         {
             long timestamp = Stopwatch.GetTimestamp();
 
-            var embedding = (await _embeddingGenerator.GenerateAsync(text))[0].Vector;
+            var embedding = (await _embeddingGenerator.GenerateAsync(new[] { text }))[0].Vector;
             embedding = embedding[0..EmbeddingDimensions];
 
             if (_logger.IsEnabled(LogLevel.Trace))

--- a/src/ClientApp/ClientApp.csproj
+++ b/src/ClientApp/ClientApp.csproj
@@ -68,9 +68,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0-rc.2.24503.2" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.*-*" />
 
     <PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />

--- a/src/HybridApp/HybridApp.csproj
+++ b/src/HybridApp/HybridApp.csproj
@@ -60,11 +60,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.0-rc.2.24503.2" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0-rc.2.24503.2" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0-rc.2.24503.2" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0-rc.2.24473.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0-rc.2.24473.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/ClientApp.UnitTests/ClientApp.UnitTests.csproj
+++ b/tests/ClientApp.UnitTests/ClientApp.UnitTests.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0-rc.2.24503.2" />
-    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0-rc.2.24503.2" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="9.0.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     


### PR DESCRIPTION
A few more updates on top of https://github.com/dotnet/eShop/pull/614

EF will update smoothly when Aspire.Npgsql.EntityFrameworkCore.PostgreSQL is updated to 9.0