### PR TITLE
Refactor Catalog API in new API version

### DIFF
--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -8,9 +8,10 @@ namespace eShop.Catalog.API;
 
 public static class CatalogApi
 {
-    public static IEndpointRouteBuilder MapCatalogApiV1(this IEndpointRouteBuilder app)
+    public static IEndpointRouteBuilder MapCatalogApi(this IEndpointRouteBuilder app)
     {
-        var api = app.MapGroup("api/catalog").HasApiVersion(1.0);
+        // EndpointRouteBuilder for endpoints in both v1 and v2
+        var api = app.NewVersionedApi("Catalog").MapGroup("api/catalog").HasApiVersion(1.0).HasApiVersion(2.0);
 
         // Routes for querying catalog items.
         api.MapGet("/items", GetAllItems)

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -54,7 +55,14 @@ public static class CatalogApi
             .WithTags("Items");
 
         // Routes for resolving catalog items using AI.
-        api.MapGet("/items/withsemanticrelevance/{text:minlength(1)}", GetItemsBySemanticRelevance)
+        v1.MapGet("/items/withsemanticrelevance/{text:minlength(1)}", GetItemsBySemanticRelevanceV1)
+            // .WithName("GetRelevantItems")
+            .WithSummary("Search catalog for relevant items")
+            .WithDescription("Search the catalog for items related to the specified text")
+            .WithTags("Search");
+
+                // Routes for resolving catalog items using AI.
+        v2.MapGet("/items/withsemanticrelevance", GetItemsBySemanticRelevance)
             .WithName("GetRelevantItems")
             .WithSummary("Search catalog for relevant items")
             .WithDescription("Search the catalog for items related to the specified text")
@@ -235,10 +243,20 @@ public static class CatalogApi
     }
 
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
-    public static async Task<Results<Ok<PaginatedItems<CatalogItem>>, RedirectToRouteHttpResult>> GetItemsBySemanticRelevance(
+    public static async Task<Results<Ok<PaginatedItems<CatalogItem>>, RedirectToRouteHttpResult>> GetItemsBySemanticRelevanceV1(
         [AsParameters] PaginationRequest paginationRequest,
         [AsParameters] CatalogServices services,
         [Description("The text string to use when search for related items in the catalog")] string text)
+
+    {
+        return await GetItemsBySemanticRelevance(paginationRequest, services, text);
+    }
+
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
+    public static async Task<Results<Ok<PaginatedItems<CatalogItem>>, RedirectToRouteHttpResult>> GetItemsBySemanticRelevance(
+        [AsParameters] PaginationRequest paginationRequest,
+        [AsParameters] CatalogServices services,
+        [Description("The text string to use when search for related items in the catalog"), Required, MinLength(1)] string text)
     {
         var pageSize = paginationRequest.PageSize;
         var pageIndex = paginationRequest.PageIndex;

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -122,7 +122,6 @@ public static class CatalogApi
         [AsParameters] PaginationRequest paginationRequest,
         [AsParameters] CatalogServices services)
     {
-
         return await GetAllItems(paginationRequest, services, null, null, null);
     }
 

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -10,11 +10,24 @@ public static class CatalogApi
 {
     public static IEndpointRouteBuilder MapCatalogApi(this IEndpointRouteBuilder app)
     {
-        // EndpointRouteBuilder for endpoints in both v1 and v2
-        var api = app.NewVersionedApi("Catalog").MapGroup("api/catalog").HasApiVersion(1.0).HasApiVersion(2.0);
+        // RouteGroupBuilder for catalog endpoints
+        // var vapi = app.NewVersionedApi("Catalog").MapGroup("api/catalog");
+        // var api = vapi.HasApiVersion(1.0).HasApiVersion(2.0);
+        // var v1 = vapi.HasApiVersion(1.0);
+        // var v2 = vapi.HasApiVersion(2.0);
+
+        var vApi = app.NewVersionedApi("Catalog");
+        var api = vApi.MapGroup("api/catalog").HasApiVersion(1, 0).HasApiVersion(2, 0);
+        var v1 = vApi.MapGroup("api/catalog").HasApiVersion(1, 0);
+        var v2 = vApi.MapGroup("api/catalog").HasApiVersion(2, 0);
 
         // Routes for querying catalog items.
-        api.MapGet("/items", GetAllItems)
+        v1.MapGet("/items", GetAllItemsV1)
+            // .WithName("ListItems")
+            .WithSummary("List catalog items")
+            .WithDescription("Get a paginated list of items in the catalog.")
+            .WithTags("Items");
+        v2.MapGet("/items", GetAllItems)
             .WithName("ListItems")
             .WithSummary("List catalog items")
             .WithDescription("Get a paginated list of items in the catalog.")
@@ -89,6 +102,15 @@ public static class CatalogApi
             .WithDescription("Delete the specified catalog item");
 
         return app;
+    }
+
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
+    public static async Task<Ok<PaginatedItems<CatalogItem>>> GetAllItemsV1(
+        [AsParameters] PaginationRequest paginationRequest,
+        [AsParameters] CatalogServices services)
+    {
+
+        return await GetAllItems(paginationRequest, services);
     }
 
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -87,7 +87,12 @@ public static class CatalogApi
             .WithTags("Brands");
 
         // Routes for modifying catalog items.
-        api.MapPut("/items", UpdateItem)
+        v1.MapPut("/items", UpdateItemV1)
+            // .WithName("UpdateItem")
+            .WithSummary("Create or replace a catalog item")
+            .WithDescription("Create or replace a catalog item")
+            .WithTags("Items");
+        v2.MapPut("/items/{id:int}", UpdateItem)
             .WithName("UpdateItem")
             .WithSummary("Create or replace a catalog item")
             .WithDescription("Create or replace a catalog item")
@@ -332,8 +337,23 @@ public static class CatalogApi
         return TypedResults.Ok(new PaginatedItems<CatalogItem>(pageIndex, pageSize, totalItems, itemsOnPage));
     }
 
-    public static async Task<Results<Created, NotFound<ProblemDetails>>> UpdateItem(
+    public static async Task<Results<Created, BadRequest<ProblemDetails>, NotFound<ProblemDetails>>> UpdateItemV1(
         HttpContext httpContext,
+        [AsParameters] CatalogServices services,
+        CatalogItem productToUpdate)
+    {
+        if (productToUpdate?.Id == null)
+        {
+            return TypedResults.BadRequest<ProblemDetails>(new (){
+                Detail = "Item id must be provided in the request body."
+            });
+        }
+        return await UpdateItem(httpContext, productToUpdate.Id, services, productToUpdate);
+    }
+
+    public static async Task<Results<Created, BadRequest<ProblemDetails>, NotFound<ProblemDetails>>> UpdateItem(
+        HttpContext httpContext,
+        [Description("The id of the catalog item to delete")] int id,
         [AsParameters] CatalogServices services,
         CatalogItem productToUpdate)
     {

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -12,11 +12,6 @@ public static class CatalogApi
     public static IEndpointRouteBuilder MapCatalogApi(this IEndpointRouteBuilder app)
     {
         // RouteGroupBuilder for catalog endpoints
-        // var vapi = app.NewVersionedApi("Catalog").MapGroup("api/catalog");
-        // var api = vapi.HasApiVersion(1.0).HasApiVersion(2.0);
-        // var v1 = vapi.HasApiVersion(1.0);
-        // var v2 = vapi.HasApiVersion(2.0);
-
         var vApi = app.NewVersionedApi("Catalog");
         var api = vApi.MapGroup("api/catalog").HasApiVersion(1, 0).HasApiVersion(2, 0);
         var v1 = vApi.MapGroup("api/catalog").HasApiVersion(1, 0);
@@ -24,12 +19,12 @@ public static class CatalogApi
 
         // Routes for querying catalog items.
         v1.MapGet("/items", GetAllItemsV1)
-            // .WithName("ListItems")
+            .WithName("ListItems")
             .WithSummary("List catalog items")
             .WithDescription("Get a paginated list of items in the catalog.")
             .WithTags("Items");
         v2.MapGet("/items", GetAllItems)
-            .WithName("ListItems")
+            .WithName("ListItems-V2")
             .WithSummary("List catalog items")
             .WithDescription("Get a paginated list of items in the catalog.")
             .WithTags("Items");
@@ -56,14 +51,14 @@ public static class CatalogApi
 
         // Routes for resolving catalog items using AI.
         v1.MapGet("/items/withsemanticrelevance/{text:minlength(1)}", GetItemsBySemanticRelevanceV1)
-            // .WithName("GetRelevantItems")
+            .WithName("GetRelevantItems")
             .WithSummary("Search catalog for relevant items")
             .WithDescription("Search the catalog for items related to the specified text")
             .WithTags("Search");
 
                 // Routes for resolving catalog items using AI.
         v2.MapGet("/items/withsemanticrelevance", GetItemsBySemanticRelevance)
-            .WithName("GetRelevantItems")
+            .WithName("GetRelevantItems-V2")
             .WithSummary("Search catalog for relevant items")
             .WithDescription("Search the catalog for items related to the specified text")
             .WithTags("Search");
@@ -96,12 +91,12 @@ public static class CatalogApi
 
         // Routes for modifying catalog items.
         v1.MapPut("/items", UpdateItemV1)
-            // .WithName("UpdateItem")
+            .WithName("UpdateItem")
             .WithSummary("Create or replace a catalog item")
             .WithDescription("Create or replace a catalog item")
             .WithTags("Items");
         v2.MapPut("/items/{id:int}", UpdateItem)
-            .WithName("UpdateItem")
+            .WithName("UpdateItem-V2")
             .WithSummary("Create or replace a catalog item")
             .WithDescription("Create or replace a catalog item")
             .WithTags("Items");
@@ -325,12 +320,12 @@ public static class CatalogApi
         [AsParameters] CatalogServices services,
         CatalogItem productToUpdate)
     {
-        var catalogItem = await services.Context.CatalogItems.SingleOrDefaultAsync(i => i.Id == productToUpdate.Id);
+        var catalogItem = await services.Context.CatalogItems.SingleOrDefaultAsync(i => i.Id == id);
 
         if (catalogItem == null)
         {
             return TypedResults.NotFound<ProblemDetails>(new (){
-                Detail = $"Item with id {productToUpdate.Id} not found."
+                Detail = $"Item with id {id} not found."
             });
         }
 
@@ -357,7 +352,7 @@ public static class CatalogApi
         {
             await services.Context.SaveChangesAsync();
         }
-        return TypedResults.Created($"/api/catalog/items/{productToUpdate.Id}");
+        return TypedResults.Created($"/api/catalog/items/{id}");
     }
 
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]

--- a/src/Catalog.API/Apis/CatalogApi.cs
+++ b/src/Catalog.API/Apis/CatalogApi.cs
@@ -202,20 +202,7 @@ public static class CatalogApi
         [AsParameters] CatalogServices services,
         [Description("The name of the item to return")] string name)
     {
-        var pageSize = paginationRequest.PageSize;
-        var pageIndex = paginationRequest.PageIndex;
-
-        var totalItems = await services.Context.CatalogItems
-            .Where(c => c.Name.StartsWith(name))
-            .LongCountAsync();
-
-        var itemsOnPage = await services.Context.CatalogItems
-            .Where(c => c.Name.StartsWith(name))
-            .Skip(pageSize * pageIndex)
-            .Take(pageSize)
-            .ToListAsync();
-
-        return TypedResults.Ok(new PaginatedItems<CatalogItem>(pageIndex, pageSize, totalItems, itemsOnPage));
+        return await GetAllItems(paginationRequest, services, name, null, null);
     }
 
     [ProducesResponseType<byte[]>(StatusCodes.Status200OK, "application/octet-stream",
@@ -307,25 +294,7 @@ public static class CatalogApi
         [Description("The type of items to return")] int typeId,
         [Description("The brand of items to return")] int? brandId)
     {
-        var pageSize = paginationRequest.PageSize;
-        var pageIndex = paginationRequest.PageIndex;
-
-        var root = (IQueryable<CatalogItem>)services.Context.CatalogItems;
-        root = root.Where(c => c.CatalogTypeId == typeId);
-        if (brandId is not null)
-        {
-            root = root.Where(c => c.CatalogBrandId == brandId);
-        }
-
-        var totalItems = await root
-            .LongCountAsync();
-
-        var itemsOnPage = await root
-            .Skip(pageSize * pageIndex)
-            .Take(pageSize)
-            .ToListAsync();
-
-        return TypedResults.Ok(new PaginatedItems<CatalogItem>(pageIndex, pageSize, totalItems, itemsOnPage));
+        return await GetAllItems(paginationRequest, services, null, typeId, brandId);
     }
 
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")]
@@ -334,25 +303,7 @@ public static class CatalogApi
         [AsParameters] CatalogServices services,
         [Description("The brand of items to return")] int? brandId)
     {
-        var pageSize = paginationRequest.PageSize;
-        var pageIndex = paginationRequest.PageIndex;
-
-        var root = (IQueryable<CatalogItem>)services.Context.CatalogItems;
-
-        if (brandId is not null)
-        {
-            root = root.Where(ci => ci.CatalogBrandId == brandId);
-        }
-
-        var totalItems = await root
-            .LongCountAsync();
-
-        var itemsOnPage = await root
-            .Skip(pageSize * pageIndex)
-            .Take(pageSize)
-            .ToListAsync();
-
-        return TypedResults.Ok(new PaginatedItems<CatalogItem>(pageIndex, pageSize, totalItems, itemsOnPage));
+        return await GetAllItems(paginationRequest, services, null, null, brandId);
     }
 
     public static async Task<Results<Created, BadRequest<ProblemDetails>, NotFound<ProblemDetails>>> UpdateItemV1(

--- a/src/Catalog.API/Catalog.API.json
+++ b/src/Catalog.API/Catalog.API.json
@@ -6,158 +6,6 @@
     "version": "1.0"
   },
   "paths": {
-    "/api/catalog/items": {
-      "get": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "List catalog items",
-        "description": "Get a paginated list of items in the catalog.",
-        "operationId": "ListItems",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "Create or replace a catalog item",
-        "description": "Create or replace a catalog item",
-        "operationId": "UpdateItem",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CatalogItem"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Catalog"
-        ],
-        "summary": "Create a catalog item",
-        "description": "Create a new item in the catalog",
-        "operationId": "CreateItem",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CatalogItem"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/catalog/items/by": {
       "get": {
         "tags": [
@@ -312,80 +160,6 @@
         }
       }
     },
-    "/api/catalog/items/by/{name}": {
-      "get": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "Get catalog items by name",
-        "description": "Get a paginated list of catalog items with the specified name.",
-        "operationId": "GetItemsByName",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "The name of the item to return",
-            "required": true,
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/catalog/items/{id}/pic": {
       "get": {
         "tags": [
@@ -521,6 +295,325 @@
             "name": "text",
             "in": "path",
             "description": "The text string to use when search for related items in the catalog",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/catalogtypes": {
+      "get": {
+        "tags": [
+          "Types"
+        ],
+        "summary": "List catalog item types",
+        "description": "Get a list of the types of catalog items",
+        "operationId": "ListItemTypes",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogType"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/catalogbrands": {
+      "get": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "List catalog item brands",
+        "description": "Get a list of the brands of catalog items",
+        "operationId": "ListItemBrands",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogBrand"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items": {
+      "put": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Create or replace a catalog item",
+        "description": "Create or replace a catalog item",
+        "operationId": "UpdateItem",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "Create a catalog item",
+        "description": "Create a new item in the catalog",
+        "operationId": "CreateItem",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "List catalog items",
+        "description": "Get a paginated list of items in the catalog.",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/by/{name}": {
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Get catalog items by name",
+        "description": "Get a paginated list of catalog items with the specified name.",
+        "operationId": "GetItemsByName",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the item to return",
             "required": true,
             "schema": {
               "minLength": 1,
@@ -703,100 +796,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/catalog/catalogtypes": {
-      "get": {
-        "tags": [
-          "Types"
-        ],
-        "summary": "List catalog item types",
-        "description": "Get a list of the types of catalog items",
-        "operationId": "ListItemTypes",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CatalogType"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/catalog/catalogbrands": {
-      "get": {
-        "tags": [
-          "Brands"
-        ],
-        "summary": "List catalog item brands",
-        "description": "Get a list of the brands of catalog items",
-        "operationId": "ListItemBrands",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CatalogBrand"
-                  }
                 }
               }
             }

--- a/src/Catalog.API/Catalog.API.json
+++ b/src/Catalog.API/Catalog.API.json
@@ -262,80 +262,6 @@
         }
       }
     },
-    "/api/catalog/items/withsemanticrelevance/{text}": {
-      "get": {
-        "tags": [
-          "Search"
-        ],
-        "summary": "Search catalog for relevant items",
-        "description": "Search the catalog for items related to the specified text",
-        "operationId": "GetRelevantItems",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "text",
-            "in": "path",
-            "description": "The text string to use when search for related items in the catalog",
-            "required": true,
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/catalog/catalogtypes": {
       "get": {
         "tags": [
@@ -623,6 +549,79 @@
             "name": "name",
             "in": "path",
             "description": "The name of the item to return",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/withsemanticrelevance/{text}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Search catalog for relevant items",
+        "description": "Search the catalog for items related to the specified text",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "text",
+            "in": "path",
+            "description": "The text string to use when search for related items in the catalog",
             "required": true,
             "schema": {
               "minLength": 1,
@@ -973,13 +972,13 @@
       "name": "Catalog"
     },
     {
-      "name": "Search"
-    },
-    {
       "name": "Types"
     },
     {
       "name": "Brands"
+    },
+    {
+      "name": "Search"
     }
   ]
 }

--- a/src/Catalog.API/Catalog.API.json
+++ b/src/Catalog.API/Catalog.API.json
@@ -407,6 +407,7 @@
         ],
         "summary": "List catalog items",
         "description": "Get a paginated list of items in the catalog.",
+        "operationId": "ListItems",
         "parameters": [
           {
             "name": "PageSize",
@@ -468,6 +469,7 @@
         ],
         "summary": "Create or replace a catalog item",
         "description": "Create or replace a catalog item",
+        "operationId": "UpdateItem",
         "parameters": [
           {
             "name": "api-version",
@@ -597,6 +599,7 @@
         ],
         "summary": "Search catalog for relevant items",
         "description": "Search the catalog for items related to the specified text",
+        "operationId": "GetRelevantItems",
         "parameters": [
           {
             "name": "PageSize",

--- a/src/Catalog.API/Catalog.API.json
+++ b/src/Catalog.API/Catalog.API.json
@@ -431,50 +431,6 @@
       }
     },
     "/api/catalog/items": {
-      "put": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "Create or replace a catalog item",
-        "description": "Create or replace a catalog item",
-        "operationId": "UpdateItem",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "1.0"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CatalogItem"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
       "post": {
         "tags": [
           "Catalog"
@@ -572,6 +528,59 @@
             "description": "Bad Request",
             "content": {
               "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Create or replace a catalog item",
+        "description": "Create or replace a catalog item",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
                 }

--- a/src/Catalog.API/Catalog.API_v2.json
+++ b/src/Catalog.API/Catalog.API_v2.json
@@ -6,158 +6,6 @@
     "version": "2.0"
   },
   "paths": {
-    "/api/catalog/items": {
-      "get": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "List catalog items",
-        "description": "Get a paginated list of items in the catalog.",
-        "operationId": "ListItems",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "Create or replace a catalog item",
-        "description": "Create or replace a catalog item",
-        "operationId": "UpdateItem",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CatalogItem"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Catalog"
-        ],
-        "summary": "Create a catalog item",
-        "description": "Create a new item in the catalog",
-        "operationId": "CreateItem",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CatalogItem"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/catalog/items/by": {
       "get": {
         "tags": [
@@ -308,80 +156,6 @@
           },
           "404": {
             "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/api/catalog/items/by/{name}": {
-      "get": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "Get catalog items by name",
-        "description": "Get a paginated list of catalog items with the specified name.",
-        "operationId": "GetItemsByName",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "The name of the item to return",
-            "required": true,
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
           }
         }
       }
@@ -562,164 +336,6 @@
         }
       }
     },
-    "/api/catalog/items/type/{typeId}/brand/{brandId}": {
-      "get": {
-        "tags": [
-          "Types"
-        ],
-        "summary": "Get catalog items by type and brand",
-        "description": "Get catalog items of the specified type and brand",
-        "operationId": "GetItemsByTypeAndBrand",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "typeId",
-            "in": "path",
-            "description": "The type of items to return",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "brandId",
-            "in": "path",
-            "description": "The brand of items to return",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/catalog/items/type/all/brand/{brandId}": {
-      "get": {
-        "tags": [
-          "Brands"
-        ],
-        "summary": "List catalog items by brand",
-        "description": "Get a list of catalog items for the specified brand",
-        "operationId": "GetItemsByBrand",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "brandId",
-            "in": "path",
-            "description": "The brand of items to return",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/catalog/catalogtypes": {
       "get": {
         "tags": [
@@ -797,6 +413,184 @@
                   "items": {
                     "$ref": "#/components/schemas/CatalogBrand"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items": {
+      "put": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Create or replace a catalog item",
+        "description": "Create or replace a catalog item",
+        "operationId": "UpdateItem",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "Create a catalog item",
+        "description": "Create a new item in the catalog",
+        "operationId": "CreateItem",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "List catalog items",
+        "description": "Get a paginated list of items in the catalog.",
+        "operationId": "ListItems",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the item to return",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The type of items to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "brand",
+            "in": "query",
+            "description": "The brand of items to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
                 }
               }
             }

--- a/src/Catalog.API/Catalog.API_v2.json
+++ b/src/Catalog.API/Catalog.API_v2.json
@@ -326,80 +326,6 @@
         }
       }
     },
-    "/api/catalog/items/withsemanticrelevance/{text}": {
-      "get": {
-        "tags": [
-          "Search"
-        ],
-        "summary": "Search catalog for relevant items",
-        "description": "Search the catalog for items related to the specified text",
-        "operationId": "GetRelevantItems",
-        "parameters": [
-          {
-            "name": "PageSize",
-            "in": "query",
-            "description": "Number of items to return in a single page of results",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "PageIndex",
-            "in": "query",
-            "description": "The index of the page of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "text",
-            "in": "path",
-            "description": "The text string to use when search for related items in the catalog",
-            "required": true,
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/catalog/catalogtypes": {
       "get": {
         "tags": [
@@ -627,6 +553,80 @@
           }
         }
       }
+    },
+    "/api/catalog/items/withsemanticrelevance": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Search catalog for relevant items",
+        "description": "Search the catalog for items related to the specified text",
+        "operationId": "GetRelevantItems",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "description": "The text string to use when search for related items in the catalog",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -779,13 +779,13 @@
       "name": "Catalog"
     },
     {
-      "name": "Search"
-    },
-    {
       "name": "Types"
     },
     {
       "name": "Brands"
+    },
+    {
+      "name": "Search"
     }
   ]
 }

--- a/src/Catalog.API/Catalog.API_v2.json
+++ b/src/Catalog.API/Catalog.API_v2.json
@@ -165,7 +165,7 @@
         ],
         "summary": "Create or replace a catalog item",
         "description": "Create or replace a catalog item",
-        "operationId": "UpdateItem",
+        "operationId": "UpdateItem-V2",
         "parameters": [
           {
             "name": "id",
@@ -471,7 +471,7 @@
         ],
         "summary": "List catalog items",
         "description": "Get a paginated list of items in the catalog.",
-        "operationId": "ListItems",
+        "operationId": "ListItems-V2",
         "parameters": [
           {
             "name": "PageSize",
@@ -561,7 +561,7 @@
         ],
         "summary": "Search catalog for relevant items",
         "description": "Search the catalog for items related to the specified text",
-        "operationId": "GetRelevantItems",
+        "operationId": "GetRelevantItems-V2",
         "parameters": [
           {
             "name": "PageSize",

--- a/src/Catalog.API/Catalog.API_v2.json
+++ b/src/Catalog.API/Catalog.API_v2.json
@@ -1,0 +1,977 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "eShop - Catalog HTTP API",
+    "description": "The Catalog Microservice HTTP API. This is a Data-Driven/CRUD microservice sample",
+    "version": "2.0"
+  },
+  "paths": {
+    "/api/catalog/items": {
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "List catalog items",
+        "description": "Get a paginated list of items in the catalog.",
+        "operationId": "ListItems",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Create or replace a catalog item",
+        "description": "Create or replace a catalog item",
+        "operationId": "UpdateItem",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "Create a catalog item",
+        "description": "Create a new item in the catalog",
+        "operationId": "CreateItem",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/by": {
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Batch get catalog items",
+        "description": "Get multiple items from the catalog",
+        "operationId": "BatchGetItems",
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "description": "List of ids for catalog items to return",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogItem"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/{id}": {
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Get catalog item",
+        "description": "Get an item from the catalog",
+        "operationId": "GetItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The catalog item id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogItem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "Delete catalog item",
+        "description": "Delete the specified catalog item",
+        "operationId": "DeleteItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the catalog item to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/catalog/items/by/{name}": {
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Get catalog items by name",
+        "description": "Get a paginated list of catalog items with the specified name.",
+        "operationId": "GetItemsByName",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the item to return",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/{id}/pic": {
+      "get": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Get catalog item picture",
+        "description": "Get the picture for a catalog item",
+        "operationId": "GetItemPicture",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The catalog item id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/bmp": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/tiff": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/wmf": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/jp2": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/svg+xml": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/withsemanticrelevance/{text}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Search catalog for relevant items",
+        "description": "Search the catalog for items related to the specified text",
+        "operationId": "GetRelevantItems",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "text",
+            "in": "path",
+            "description": "The text string to use when search for related items in the catalog",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/type/{typeId}/brand/{brandId}": {
+      "get": {
+        "tags": [
+          "Types"
+        ],
+        "summary": "Get catalog items by type and brand",
+        "description": "Get catalog items of the specified type and brand",
+        "operationId": "GetItemsByTypeAndBrand",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "typeId",
+            "in": "path",
+            "description": "The type of items to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "brandId",
+            "in": "path",
+            "description": "The brand of items to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/items/type/all/brand/{brandId}": {
+      "get": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "List catalog items by brand",
+        "description": "Get a list of catalog items for the specified brand",
+        "operationId": "GetItemsByBrand",
+        "parameters": [
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items to return in a single page of results",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "PageIndex",
+            "in": "query",
+            "description": "The index of the page of results to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "brandId",
+            "in": "path",
+            "description": "The brand of items to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItemsOfCatalogItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/catalogtypes": {
+      "get": {
+        "tags": [
+          "Types"
+        ],
+        "summary": "List catalog item types",
+        "description": "Get a list of the types of catalog items",
+        "operationId": "ListItemTypes",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogType"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catalog/catalogbrands": {
+      "get": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "List catalog item brands",
+        "description": "Get a list of the brands of catalog items",
+        "operationId": "ListItemBrands",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CatalogBrand"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CatalogBrand": {
+        "required": [
+          "brand"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "brand": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "CatalogItem": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number",
+            "format": "double"
+          },
+          "pictureFileName": {
+            "type": "string"
+          },
+          "catalogTypeId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "catalogType": {
+            "$ref": "#/components/schemas/CatalogType"
+          },
+          "catalogBrandId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "catalogBrand": {
+            "$ref": "#/components/schemas/CatalogBrand"
+          },
+          "availableStock": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "restockThreshold": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStockThreshold": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "onReorder": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CatalogType": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "PaginatedItemsOfCatalogItem": {
+        "required": [
+          "pageIndex",
+          "pageSize",
+          "count",
+          "data"
+        ],
+        "type": "object",
+        "properties": {
+          "pageIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatalogItem"
+            },
+            "nullable": true
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "instance": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Items"
+    },
+    {
+      "name": "Catalog"
+    },
+    {
+      "name": "Search"
+    },
+    {
+      "name": "Types"
+    },
+    {
+      "name": "Brands"
+    }
+  ]
+}

--- a/src/Catalog.API/Catalog.API_v2.json
+++ b/src/Catalog.API/Catalog.API_v2.json
@@ -158,6 +158,70 @@
             "description": "Not Found"
           }
         }
+      },
+      "put": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "Create or replace a catalog item",
+        "description": "Create or replace a catalog item",
+        "operationId": "UpdateItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the catalog item to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version, in the format 'major.minor'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "2.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/catalog/items/{id}/pic": {
@@ -431,50 +495,6 @@
       }
     },
     "/api/catalog/items": {
-      "put": {
-        "tags": [
-          "Items"
-        ],
-        "summary": "Create or replace a catalog item",
-        "description": "Create or replace a catalog item",
-        "operationId": "UpdateItem",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version, in the format 'major.minor'.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "2.0"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CatalogItem"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
       "post": {
         "tags": [
           "Catalog"

--- a/src/Catalog.API/Program.cs
+++ b/src/Catalog.API/Program.cs
@@ -17,8 +17,7 @@ app.MapDefaultEndpoints();
 
 app.UseStatusCodePages();
 
-app.NewVersionedApi("Catalog")
-   .MapCatalogApiV1();
+app.MapCatalogApi();
 
 app.UseDefaultOpenApi();
 app.Run();

--- a/src/ClientApp/Services/Catalog/CatalogService.cs
+++ b/src/ClientApp/Services/Catalog/CatalogService.cs
@@ -9,8 +9,8 @@ namespace eShop.ClientApp.Services.Catalog;
 public class CatalogService : ICatalogService
 {
     private const string ApiUrlBase = "api/catalog";
-    private const string ApiVersion = "api-version=1.0";
-    
+    private const string ApiVersion = "api-version=2.0";
+
     private readonly IFixUriService _fixUriService;
     private readonly IRequestProvider _requestProvider;
     private readonly ISettingsService _settingsService;
@@ -26,7 +26,7 @@ public class CatalogService : ICatalogService
     public async Task<IEnumerable<CatalogItem>> FilterAsync(int catalogBrandId, int catalogTypeId)
     {
         var uri = UriHelper.CombineUri(_settingsService.GatewayCatalogEndpointBase,
-            $"{ApiUrlBase}/items/type/{catalogTypeId}/brand/{catalogBrandId}?PageSize=100&PageIndex=0&{ApiVersion}");
+            $"{ApiUrlBase}//items?type={catalogTypeId}&brand={catalogBrandId}&PageSize=100&PageIndex=0&{ApiVersion}");
 
         var catalog = await _requestProvider.GetAsync<CatalogRoot>(uri).ConfigureAwait(false);
 

--- a/src/ClientApp/Services/FixUri/FixUriService.cs
+++ b/src/ClientApp/Services/FixUri/FixUriService.cs
@@ -9,8 +9,8 @@ namespace eShop.ClientApp.Services.FixUri;
 
 public class FixUriService : IFixUriService
 {
-    private const string ApiVersion = "api-version=1.0";
-    
+    private const string ApiVersion = "api-version=2.0";
+
     private readonly ISettingsService _settingsService;
 
     private readonly Regex IpRegex = new(@"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b");

--- a/src/HybridApp/Services/CatalogService.cs
+++ b/src/HybridApp/Services/CatalogService.cs
@@ -12,65 +12,58 @@ public class CatalogService(HttpClient httpClient) : ICatalogService
 
     public Task<CatalogItem?> GetCatalogItem(int id)
     {
-        var uri = $"{remoteServiceBaseUrl}items/{id}?api-version=1.0";
+        var uri = $"{remoteServiceBaseUrl}items/{id}?api-version=2.0";
         return httpClient.GetFromJsonAsync<CatalogItem>(uri);
     }
 
     public async Task<CatalogResult> GetCatalogItems(int pageIndex, int pageSize, int? brand, int? type)
     {
         var uri = GetAllCatalogItemsUri(remoteServiceBaseUrl, pageIndex, pageSize, brand, type);
-        var result = await httpClient.GetFromJsonAsync<CatalogResult>($"{uri}&api-version=1.0");
+        var result = await httpClient.GetFromJsonAsync<CatalogResult>($"{uri}&api-version=2.0");
         return result!;
     }
 
     public async Task<List<CatalogItem>> GetCatalogItems(IEnumerable<int> ids)
     {
-        var uri = $"{remoteServiceBaseUrl}items/by?ids={string.Join("&ids=", ids)}&api-version=1.0";
+        var uri = $"{remoteServiceBaseUrl}items/by?ids={string.Join("&ids=", ids)}&api-version=2.0";
         var result = await httpClient.GetFromJsonAsync<List<CatalogItem>>(uri);
         return result!;
     }
 
     public Task<CatalogResult> GetCatalogItemsWithSemanticRelevance(int page, int take, string text)
     {
-        var url = $"{remoteServiceBaseUrl}items/withsemanticrelevance/{HttpUtility.UrlEncode(text)}?pageIndex={page}&pageSize={take}&api-version=1.0";
+        var url = $"{remoteServiceBaseUrl}items/withsemanticrelevance?text={HttpUtility.UrlEncode(text)}&pageIndex={page}&pageSize={take}&api-version=2.0";
         var result = httpClient.GetFromJsonAsync<CatalogResult>(url);
         return result!;
     }
 
     public async Task<IEnumerable<CatalogBrand>> GetBrands()
     {
-        var uri = $"{remoteServiceBaseUrl}catalogBrands?api-version=1.0";
+        var uri = $"{remoteServiceBaseUrl}catalogBrands?api-version=2.0";
         var result = await httpClient.GetFromJsonAsync<CatalogBrand[]>(uri);
         return result!;
     }
 
     public async Task<IEnumerable<CatalogItemType>> GetTypes()
     {
-        var uri = $"{remoteServiceBaseUrl}catalogTypes?api-version=1.0";
+        var uri = $"{remoteServiceBaseUrl}catalogTypes?api-version=2.0";
         var result = await httpClient.GetFromJsonAsync<CatalogItemType[]>(uri);
         return result!;
     }
 
     private static string GetAllCatalogItemsUri(string baseUri, int pageIndex, int pageSize, int? brand, int? type)
     {
-        string filterQs;
+        string filterQs = string.Empty;
 
         if (type.HasValue)
         {
-            var brandQs = brand.HasValue ? brand.Value.ToString() : string.Empty;
-            filterQs = $"/type/{type.Value}/brand/{brandQs}";
-
+            filterQs += $"type={type.Value}&";
         }
-        else if (brand.HasValue)
+        if (brand.HasValue)
         {
-            var brandQs = brand.HasValue ? brand.Value.ToString() : string.Empty;
-            filterQs = $"/type/all/brand/{brandQs}";
-        }
-        else
-        {
-            filterQs = string.Empty;
+            filterQs += $"brand={brand.Value}&";
         }
 
-        return $"{baseUri}items{filterQs}?pageIndex={pageIndex}&pageSize={pageSize}&api-version=1.0";
+        return $"{baseUri}items?{filterQs}pageIndex={pageIndex}&pageSize={pageSize}&api-version=2.0";
     }
 }

--- a/src/HybridApp/Services/ProductImageUrlProvider.cs
+++ b/src/HybridApp/Services/ProductImageUrlProvider.cs
@@ -5,5 +5,5 @@ namespace eShop.HybridApp.Services;
 public class ProductImageUrlProvider : IProductImageUrlProvider
 {
     public string GetProductImageUrl(int productId)
-        => $"{MauiProgram.MobileBffHost}api/catalog/items/{productId}/pic?api-version=1.0";
+        => $"{MauiProgram.MobileBffHost}api/catalog/items/{productId}/pic?api-version=2.0";
 }

--- a/src/Mobile.Bff.Shopping/appsettings.json
+++ b/src/Mobile.Bff.Shopping/appsettings.json
@@ -17,7 +17,7 @@
           "QueryParameters": [
             {
               "Name": "api-version",
-              "Values": [ "1.0", "1" ],
+              "Values": [ "1.0", "1", "2.0" ],
               "Mode": "Exact"
             }
           ]
@@ -35,7 +35,7 @@
           "QueryParameters": [
             {
               "Name": "api-version",
-              "Values": [ "1.0", "1" ],
+              "Values": [ "1.0", "1", "2.0" ],
               "Mode": "Exact"
             }
           ]
@@ -53,7 +53,7 @@
           "QueryParameters": [
             {
               "Name": "api-version",
-              "Values": [ "1.0", "1" ],
+              "Values": [ "1.0", "1", "2.0" ],
               "Mode": "Exact"
             }
           ]
@@ -82,7 +82,7 @@
           }
         ]
       },
-      "route5": {
+      "route5v1": {
         "ClusterId": "catalog",
         "Match": {
           "Path": "/catalog-api/api/catalog/items/withsemanticrelevance/{text}",
@@ -90,6 +90,24 @@
             {
               "Name": "api-version",
               "Values": [ "1.0", "1" ],
+              "Mode": "Exact"
+            }
+          ]
+        },
+        "Transforms": [
+          {
+            "PathRemovePrefix": "/catalog-api"
+          }
+        ]
+      },
+      "route5": {
+        "ClusterId": "catalog",
+        "Match": {
+          "Path": "/catalog-api/api/catalog/items/withsemanticrelevance",
+          "QueryParameters": [
+            {
+              "Name": "api-version",
+              "Values": [ "2.0" ],
               "Mode": "Exact"
             }
           ]
@@ -143,7 +161,7 @@
           "QueryParameters": [
             {
               "Name": "api-version",
-              "Values": [ "1.0", "1" ],
+              "Values": [ "1.0", "1", "2.0" ],
               "Mode": "Exact"
             }
           ]
@@ -161,7 +179,7 @@
           "QueryParameters": [
             {
               "Name": "api-version",
-              "Values": [ "1.0", "1" ],
+              "Values": [ "1.0", "1", "2.0" ],
               "Mode": "Exact"
             }
           ]
@@ -179,7 +197,7 @@
           "QueryParameters": [
             {
               "Name": "api-version",
-              "Values": [ "1.0", "1" ],
+              "Values": [ "1.0", "1", "2.0" ],
               "Mode": "Exact"
             }
           ]
@@ -197,7 +215,7 @@
           "QueryParameters": [
             {
               "Name": "api-version",
-              "Values": [ "1.0", "1" ],
+              "Values": [ "1.0", "1", "2.0" ],
               "Mode": "Exact"
             }
           ]

--- a/src/WebApp/Extensions/Extensions.cs
+++ b/src/WebApp/Extensions/Extensions.cs
@@ -37,7 +37,7 @@ public static class Extensions
             .AddAuthToken();
 
         builder.Services.AddHttpClient<CatalogService>(o => o.BaseAddress = new("http://catalog-api"))
-            .AddApiVersion(1.0)
+            .AddApiVersion(2.0)
             .AddAuthToken();
 
         builder.Services.AddHttpClient<OrderingService>(o => o.BaseAddress = new("http://ordering-api"))

--- a/src/WebApp/Services/ProductImageUrlProvider.cs
+++ b/src/WebApp/Services/ProductImageUrlProvider.cs
@@ -5,5 +5,5 @@ namespace eShop.WebApp.Services;
 public class ProductImageUrlProvider : IProductImageUrlProvider
 {
     public string GetProductImageUrl(int productId)
-        => $"product-images/{productId}?api-version=1.0";
+        => $"product-images/{productId}?api-version=2.0";
 }

--- a/src/WebAppComponents/Services/CatalogService.cs
+++ b/src/WebAppComponents/Services/CatalogService.cs
@@ -30,7 +30,7 @@ public class CatalogService(HttpClient httpClient) : ICatalogService
 
     public Task<CatalogResult> GetCatalogItemsWithSemanticRelevance(int page, int take, string text)
     {
-        var url = $"{remoteServiceBaseUrl}items/withsemanticrelevance/{HttpUtility.UrlEncode(text)}?pageIndex={page}&pageSize={take}";
+        var url = $"{remoteServiceBaseUrl}items/withsemanticrelevance?text={HttpUtility.UrlEncode(text)}&pageIndex={page}&pageSize={take}";
         var result = httpClient.GetFromJsonAsync<CatalogResult>(url);
         return result!;
     }
@@ -51,24 +51,17 @@ public class CatalogService(HttpClient httpClient) : ICatalogService
 
     private static string GetAllCatalogItemsUri(string baseUri, int pageIndex, int pageSize, int? brand, int? type)
     {
-        string filterQs;
+        string filterQs = string.Empty;
 
         if (type.HasValue)
         {
-            var brandQs = brand.HasValue ? brand.Value.ToString() : string.Empty;
-            filterQs = $"/type/{type.Value}/brand/{brandQs}";
-
+            filterQs += $"type={type.Value}&";
         }
-        else if (brand.HasValue)
+        if (brand.HasValue)
         {
-            var brandQs = brand.HasValue ? brand.Value.ToString() : string.Empty;
-            filterQs = $"/type/all/brand/{brandQs}";
-        }
-        else
-        {
-            filterQs = string.Empty;
+            filterQs += $"brand={brand.Value}&";
         }
 
-        return $"{baseUri}items{filterQs}?pageIndex={pageIndex}&pageSize={pageSize}";
+        return $"{baseUri}items?{filterQs}pageIndex={pageIndex}&pageSize={pageSize}";
     }
 }

--- a/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
@@ -58,7 +58,7 @@ public static partial class Extensions
             // the default format will just be ApiVersion.ToString(); for example, 1.0.
             // this will format the version as "'v'major[.minor][-status]"
             var versioned = apiVersioning.AddApiExplorer(options => options.GroupNameFormat = "'v'VVV");
-            string[] versions = ["v1"];
+            string[] versions = ["v1", "v2"];
             foreach (var description in versions)
             {
                 builder.Services.AddOpenApi(description, options =>

--- a/src/eShop.ServiceDefaults/OpenApiOptionsExtensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApiOptionsExtensions.cs
@@ -3,6 +3,7 @@ using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -158,7 +159,14 @@ internal static class OpenApiOptionsExtensions
             if (apiVersionParameter is not null)
             {
                 apiVersionParameter.Description = "The API version, in the format 'major.minor'.";
-                apiVersionParameter.Schema.Example = new OpenApiString("1.0");
+                switch (context.DocumentName) {
+                    case "v1":
+                        apiVersionParameter.Schema.Example = new OpenApiString("1.0");
+                        break;
+                    case "v2":
+                        apiVersionParameter.Schema.Example = new OpenApiString("2.0");
+                        break;
+                }
             }
             return Task.CompletedTask;
         });

--- a/tests/Catalog.FunctionalTests/CatalogApiTests.cs
+++ b/tests/Catalog.FunctionalTests/CatalogApiTests.cs
@@ -238,7 +238,12 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         var _httpClient = CreateHttpClient(new ApiVersion(version));
 
         // Act
-        var response = await _httpClient.GetAsync("api/catalog/items/withsemanticrelevance/Wanderer?PageSize=5&PageIndex=0");
+        var response = version switch
+        {
+            1.0 => await _httpClient.GetAsync("api/catalog/items/withsemanticrelevance/Wanderer?PageSize=5&PageIndex=0"),
+            2.0 => await _httpClient.GetAsync("api/catalog/items/withsemanticrelevance?text=Wanderer&PageSize=5&PageIndex=0"),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
+        };
 
         // Arrange
         response.EnsureSuccessStatusCode();

--- a/tests/Catalog.FunctionalTests/CatalogApiTests.cs
+++ b/tests/Catalog.FunctionalTests/CatalogApiTests.cs
@@ -4,6 +4,7 @@ using Asp.Versioning;
 using Asp.Versioning.Http;
 using eShop.Catalog.API.Model;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace eShop.Catalog.FunctionalTests;
 
@@ -153,7 +154,12 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         var _httpClient = CreateHttpClient(new ApiVersion(version));
 
         // Act
-        var response = await _httpClient.GetAsync("api/catalog/items/by/Wanderer%20Black%20Hiking%20Boots?PageSize=5&PageIndex=0");
+        var response = version switch
+        {
+            1.0 => await _httpClient.GetAsync("api/catalog/items/by/Wanderer%20Black%20Hiking%20Boots?PageSize=5&PageIndex=0"),
+            2.0 => await _httpClient.GetAsync("api/catalog/items?name=Wanderer%20Black%20Hiking%20Boots&PageSize=5&PageIndex=0"),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
+        };
 
         // Arrange
         response.EnsureSuccessStatusCode();
@@ -176,7 +182,12 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         var _httpClient = CreateHttpClient(new ApiVersion(version));
 
         // Act
-        var response = await _httpClient.GetAsync("api/catalog/items/by/Alpine?PageSize=5&PageIndex=0");
+        var response = version switch
+        {
+            1.0 => await _httpClient.GetAsync("api/catalog/items/by/Alpine?PageSize=5&PageIndex=0"),
+            2.0 => await _httpClient.GetAsync("api/catalog/items?name=Alpine&PageSize=5&PageIndex=0"),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
+        };
 
         // Arrange
         response.EnsureSuccessStatusCode();
@@ -239,7 +250,12 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         var _httpClient = CreateHttpClient(new ApiVersion(version));
 
         // Act
-        var response = await _httpClient.GetAsync("api/catalog/items/type/3/brand/3?PageSize=5&PageIndex=0");
+        var response = version switch
+        {
+            1.0 => await _httpClient.GetAsync("api/catalog/items/type/3/brand/3?PageSize=5&PageIndex=0"),
+            2.0 => await _httpClient.GetAsync("api/catalog/items?type=3&brand=3&PageSize=5&PageIndex=0"),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
+        };
 
         // Arrange
         response.EnsureSuccessStatusCode();
@@ -263,7 +279,12 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         var _httpClient = CreateHttpClient(new ApiVersion(version));
 
         // Act
-        var response = await _httpClient.GetAsync("api/catalog/items/type/all/brand/3?PageSize=5&PageIndex=0");
+        var response = version switch
+        {
+            1.0 => await _httpClient.GetAsync("api/catalog/items/type/all/brand/3?PageSize=5&PageIndex=0"),
+            2.0 => await _httpClient.GetAsync("api/catalog/items?brand=3&PageSize=5&PageIndex=0"),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
+        };
 
         // Arrange
         response.EnsureSuccessStatusCode();

--- a/tests/Catalog.FunctionalTests/CatalogApiTests.cs
+++ b/tests/Catalog.FunctionalTests/CatalogApiTests.cs
@@ -4,7 +4,6 @@ using Asp.Versioning;
 using Asp.Versioning.Http;
 using eShop.Catalog.API.Model;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace eShop.Catalog.FunctionalTests;
 

--- a/tests/Catalog.FunctionalTests/CatalogApiTests.cs
+++ b/tests/Catalog.FunctionalTests/CatalogApiTests.cs
@@ -10,20 +10,26 @@ namespace eShop.Catalog.FunctionalTests;
 public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
 {
     private readonly WebApplicationFactory<Program> _webApplicationFactory;
-    private readonly HttpClient _httpClient;
     private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
     public CatalogApiTests(CatalogApiFixture fixture)
     {
-        var handler = new ApiVersionHandler(new QueryStringApiVersionWriter(), new ApiVersion(1.0));
-
         _webApplicationFactory = fixture;
-        _httpClient = _webApplicationFactory.CreateDefaultClient(handler);
     }
 
-    [Fact]
-    public async Task GetCatalogItemsRespectsPageSize()
+    private HttpClient CreateHttpClient(ApiVersion apiVersion)
     {
+        var handler = new ApiVersionHandler(new QueryStringApiVersionWriter(), apiVersion);
+        return _webApplicationFactory.CreateDefaultClient(handler);
+    }
+
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemsRespectsPageSize(double version)
+    {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("/api/catalog/items?pageIndex=0&pageSize=5");
 
@@ -38,9 +44,13 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         Assert.Equal(5, result.PageSize);
     }
 
-    [Fact]
-    public async Task UpdateCatalogItemWorksWithoutPriceUpdate()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task UpdateCatalogItemWorksWithoutPriceUpdate(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act - 1
         var response = await _httpClient.GetAsync("/api/catalog/items/1");
         response.EnsureSuccessStatusCode();
@@ -64,9 +74,13 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         Assert.NotEqual(priorAvailableStock, updatedItem.AvailableStock);
     }
 
-    [Fact]
-    public async Task UpdateCatalogItemWorksWithPriceUpdate()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task UpdateCatalogItemWorksWithPriceUpdate(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act - 1
         var response = await _httpClient.GetAsync("/api/catalog/items/1");
         response.EnsureSuccessStatusCode();
@@ -92,44 +106,56 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         Assert.NotEqual(priorAvailableStock, updatedItem.AvailableStock);
     }
 
-    [Fact]
-    public async Task GetCatalogItemsbyIds()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemsbyIds(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("/api/catalog/items/by?ids=1&ids=2&ids=3");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<List<CatalogItem>>(body, _jsonSerializerOptions);
 
-        // Assert 3 items      
+        // Assert 3 items
         Assert.Equal(3, result.Count);
     }
 
-    [Fact]
-    public async Task GetCatalogItemWithId()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemWithId(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("/api/catalog/items/2");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<CatalogItem>(body, _jsonSerializerOptions);
 
-        // Assert       
+        // Assert
         Assert.Equal(2, result.Id);
         Assert.NotNull(result);
     }
 
-    [Fact]
-    public async Task GetCatalogItemWithExactName()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemWithExactName(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("api/catalog/items/by/Wanderer%20Black%20Hiking%20Boots?PageSize=5&PageIndex=0");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<PaginatedItems<CatalogItem>>(body, _jsonSerializerOptions);
@@ -142,14 +168,17 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         Assert.Equal("Wanderer Black Hiking Boots", result.Data.ToList().FirstOrDefault().Name);
     }
 
-    // searching partial name Alpine
-    [Fact]
-    public async Task GetCatalogItemWithPartialName()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemWithPartialName(double version)
     {
-       // Act
-       var response = await _httpClient.GetAsync("api/catalog/items/by/Alpine?PageSize=5&PageIndex=0");
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
 
-        // Arrange   
+        // Act
+        var response = await _httpClient.GetAsync("api/catalog/items/by/Alpine?PageSize=5&PageIndex=0");
+
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<PaginatedItems<CatalogItem>>(body, _jsonSerializerOptions);
@@ -162,52 +191,62 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         Assert.Contains("Alpine", result.Data.ToList().FirstOrDefault().Name);
     }
 
-
-    [Fact]
-    public async Task GetCatalogItemPicWithId()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemPicWithId(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("api/catalog/items/1/pic");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var result = response.Content.Headers.ContentType.MediaType;
 
-        // Assert       
+        // Assert
         Assert.Equal("image/webp", result);
     }
 
-
-    [Fact]
-    public async Task GetCatalogItemWithsemanticrelevance()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemWithsemanticrelevance(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("api/catalog/items/withsemanticrelevance/Wanderer?PageSize=5&PageIndex=0");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<PaginatedItems<CatalogItem>>(body, _jsonSerializerOptions);
 
-        // Assert       
+        // Assert
         Assert.Equal(1, result.Count);
         Assert.NotNull(result.Data);
         Assert.Equal(0, result.PageIndex);
         Assert.Equal(5, result.PageSize);
     }
 
-    [Fact]
-    public async Task GetCatalogItemWithTypeIdBrandId()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetCatalogItemWithTypeIdBrandId(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("api/catalog/items/type/3/brand/3?PageSize=5&PageIndex=0");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<PaginatedItems<CatalogItem>>(body, _jsonSerializerOptions);
 
-        // Assert    
+        // Assert
         Assert.NotNull(result.Data);
         Assert.Equal(4, result.Count);
         Assert.Equal(0, result.PageIndex);
@@ -216,9 +255,13 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         Assert.Equal(3, result.Data.ToList().FirstOrDefault().CatalogBrandId);
     }
 
-    [Fact]
-    public async Task GetAllCatalogTypeItemWithBrandId()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetAllCatalogTypeItemWithBrandId(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("api/catalog/items/type/all/brand/3?PageSize=5&PageIndex=0");
 
@@ -227,7 +270,7 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<PaginatedItems<CatalogItem>>(body, _jsonSerializerOptions);
 
-        // Assert              
+        // Assert
         Assert.NotNull(result.Data);
         Assert.Equal(11, result.Count);
         Assert.Equal(0, result.PageIndex);
@@ -235,44 +278,62 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         Assert.Equal(3, result.Data.ToList().FirstOrDefault().CatalogBrandId);
     }
 
-    [Fact]
-    public async Task GetAllCatalogTypes()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetAllCatalogTypes(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("api/catalog/catalogtypes");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<List<CatalogType>>(body, _jsonSerializerOptions);
 
-        // Assert       
+        // Assert
         Assert.Equal(8, result.Count);
         Assert.NotNull(result);
     }
 
-    [Fact]
-    public async Task GetAllCatalogBrands()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task GetAllCatalogBrands(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
         // Act
         var response = await _httpClient.GetAsync("api/catalog/catalogbrands");
 
-        // Arrange   
+        // Arrange
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<List<CatalogBrand>>(body, _jsonSerializerOptions);
 
-        // Assert       
+        // Assert
         Assert.Equal(13, result.Count);
         Assert.NotNull(result);
     }
 
-    [Fact]
-    public async Task AddCatalogItem()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task AddCatalogItem(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
+        var id = version switch {
+            1.0 => 10015,
+            2.0 => 10016,
+            _ => 0
+        };
+
         // Act - 1
         var bodyContent = new CatalogItem {
-            Id = 10015,
+            Id = id,
             Name = "TestCatalog1",
             Description = "Test catalog description 1",
             Price = 11000.08m,
@@ -290,7 +351,7 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         response.EnsureSuccessStatusCode();
 
         // Act - 2
-        response = await _httpClient.GetAsync("/api/catalog/items/10015");
+        response = await _httpClient.GetAsync($"/api/catalog/items/{id}");
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         var addedItem = JsonSerializer.Deserialize<CatalogItem>(body, _jsonSerializerOptions);
@@ -300,15 +361,25 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
 
     }
 
-    [Fact]
-    public async Task DeleteCatalogItem()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task DeleteCatalogItem(double version)
     {
+        var _httpClient = CreateHttpClient(new ApiVersion(version));
+
+        var id = version switch {
+            1.0 => 5,
+            2.0 => 6,
+            _ => 0
+        };
+
         //Act - 1
-        var response = await _httpClient.DeleteAsync("/api/catalog/items/5");
+        var response = await _httpClient.DeleteAsync($"/api/catalog/items/{id}");
         response.EnsureSuccessStatusCode();
 
         // Act - 2
-        var response1 = await _httpClient.GetAsync("/api/catalog/items/5");
+        var response1 = await _httpClient.GetAsync($"/api/catalog/items/{id}");
         var responseStatus = response1.StatusCode;
 
         // Assert - 1

--- a/tests/Catalog.FunctionalTests/CatalogApiTests.cs
+++ b/tests/Catalog.FunctionalTests/CatalogApiTests.cs
@@ -61,7 +61,12 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         // Act - 2
         var priorAvailableStock = itemToUpdate.AvailableStock;
         itemToUpdate.AvailableStock -= 1;
-        response = await _httpClient.PutAsJsonAsync("/api/catalog/items", itemToUpdate);
+        response = version switch
+        {
+            1.0 => await _httpClient.PutAsJsonAsync("/api/catalog/items", itemToUpdate),
+            2.0 => await _httpClient.PutAsJsonAsync($"/api/catalog/items/{itemToUpdate.Id}", itemToUpdate),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
+        };
         response.EnsureSuccessStatusCode();
 
         // Act - 3
@@ -92,7 +97,12 @@ public sealed class CatalogApiTests : IClassFixture<CatalogApiFixture>
         var priorAvailableStock = itemToUpdate.AvailableStock;
         itemToUpdate.AvailableStock -= 1;
         itemToUpdate.Price = 1.99m;
-        response = await _httpClient.PutAsJsonAsync("/api/catalog/items", itemToUpdate);
+        response = version switch
+        {
+            1.0 => await _httpClient.PutAsJsonAsync("/api/catalog/items", itemToUpdate),
+            2.0 => await _httpClient.PutAsJsonAsync($"/api/catalog/items/{itemToUpdate.Id}", itemToUpdate),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
+        };
         response.EnsureSuccessStatusCode();
 
         // Act - 3


### PR DESCRIPTION
This PR refactors the Catalog API to adopt more commonly accepted REST API conventions. The existing V1 API is unchanged and all refactoring is done in a new API version, V2.

Fixes #589.

Note: I have not tested the clients yet, so will move this to draft until that is done.