### PR TITLE
Cleanup: Removed Redundant Usings and Unused Private Function

### DIFF
--- a/src/eShop.ServiceDefaults/OpenApiOptionsExtensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApiOptionsExtensions.cs
@@ -2,8 +2,6 @@
 using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -171,18 +169,6 @@ internal static class OpenApiOptionsExtensions
             return Task.CompletedTask;
         });
         return options;
-    }
-
-    private static IOpenApiAny? CreateOpenApiAnyFromObject(object value)
-    {
-        return value switch
-        {
-            bool b => new OpenApiBoolean(b),
-            int i => new OpenApiInteger(i),
-            double d => new OpenApiDouble(d),
-            string s => new OpenApiString(s),
-            _ => null
-        };
     }
 
     // This extension method adds a schema transformer that sets "nullable" to false for all optional properties.


### PR DESCRIPTION
This PR includes the following cleanup updates:

Removed redundant using statements:
- using Microsoft.AspNetCore.Mvc.ModelBinding;
- using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;

These were no longer necessary and have been removed for improved code clarity.

Removed unused private function:
**CreateOpenApiAnyFromObject**: This function was identified as unused and has been removed to eliminate dead code.