### PR TITLE
Cleanup Unused Dependencies and Functions in CreateOrderCommandHandler and Test Class

### DIFF
--- a/src/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
+++ b/src/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
@@ -7,21 +7,16 @@ public class CreateOrderCommandHandler
     : IRequestHandler<CreateOrderCommand, bool>
 {
     private readonly IOrderRepository _orderRepository;
-    private readonly IIdentityService _identityService;
-    private readonly IMediator _mediator;
     private readonly IOrderingIntegrationEventService _orderingIntegrationEventService;
     private readonly ILogger<CreateOrderCommandHandler> _logger;
 
     // Using DI to inject infrastructure persistence Repositories
-    public CreateOrderCommandHandler(IMediator mediator,
-        IOrderingIntegrationEventService orderingIntegrationEventService,
+    public CreateOrderCommandHandler(
         IOrderRepository orderRepository,
-        IIdentityService identityService,
+        IOrderingIntegrationEventService orderingIntegrationEventService,
         ILogger<CreateOrderCommandHandler> logger)
     {
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
-        _identityService = identityService ?? throw new ArgumentNullException(nameof(identityService));
-        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _orderingIntegrationEventService = orderingIntegrationEventService ?? throw new ArgumentNullException(nameof(orderingIntegrationEventService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }

--- a/tests/Ordering.UnitTests/Application/NewOrderCommandHandlerTest.cs
+++ b/tests/Ordering.UnitTests/Application/NewOrderCommandHandlerTest.cs
@@ -7,24 +7,18 @@ namespace eShop.Ordering.UnitTests.Application;
 public class NewOrderRequestHandlerTest
 {
     private readonly IOrderRepository _orderRepositoryMock;
-    private readonly IIdentityService _identityServiceMock;
-    private readonly IMediator _mediator;
     private readonly IOrderingIntegrationEventService _orderingIntegrationEventService;
 
     public NewOrderRequestHandlerTest()
     {
 
         _orderRepositoryMock = Substitute.For<IOrderRepository>();
-        _identityServiceMock = Substitute.For<IIdentityService>();
         _orderingIntegrationEventService = Substitute.For<IOrderingIntegrationEventService>();
-        _mediator = Substitute.For<IMediator>();
     }
 
     [TestMethod]
     public async Task Handle_return_false_if_order_is_not_persisted()
     {
-        var buyerId = "1234";
-
         var fakeOrderCmd = FakeOrderRequestWithBuyer(new Dictionary<string, object>
         { ["cardExpiration"] = DateTime.UtcNow.AddYears(1) });
 
@@ -34,11 +28,9 @@ public class NewOrderRequestHandlerTest
         _orderRepositoryMock.UnitOfWork.SaveChangesAsync(default)
             .Returns(Task.FromResult(1));
 
-        _identityServiceMock.GetUserIdentity().Returns(buyerId);
-
         var LoggerMock = Substitute.For<ILogger<CreateOrderCommandHandler>>();
         //Act
-        var handler = new CreateOrderCommandHandler(_mediator, _orderingIntegrationEventService, _orderRepositoryMock, _identityServiceMock, LoggerMock);
+        var handler = new CreateOrderCommandHandler(_orderRepositoryMock, _orderingIntegrationEventService, LoggerMock);
         var cltToken = new CancellationToken();
         var result = await handler.Handle(fakeOrderCmd, cltToken);
 
@@ -51,11 +43,6 @@ public class NewOrderRequestHandlerTest
     {
         //Assert
         Assert.ThrowsException<ArgumentNullException>(() => new Buyer(string.Empty, string.Empty));
-    }
-
-    private Buyer FakeBuyer()
-    {
-        return new Buyer(Guid.NewGuid().ToString(), "1");
     }
 
     private Order FakeOrder()


### PR DESCRIPTION
This PR focuses on code cleanup and refactoring to improve maintainability and readability by removing unused parameters and functions in the codebase. The following changes have been made:

Removed Unused Dependencies in CreateOrderCommandHandler:
Deleted the unused private readonly fields:
_identityService (IIdentityService)
_mediator (IMediator)

Updated Test Class NewOrderRequestHandlerTest:
Adjusted the test class to reflect the changes in CreateOrderCommandHandler by removing references or logic that depended on the eliminated dependencies.

Removed Unused Private Function in NewOrderRequestHandlerTest:
Deleted the FakeBuyer private function, which was no longer utilized within the test class.