### PR TITLE
Refactor _subscriptionsLock to use Lock type

### DIFF
--- a/src/WebApp/Services/OrderStatus/OrderStatusNotificationService.cs
+++ b/src/WebApp/Services/OrderStatus/OrderStatusNotificationService.cs
@@ -3,7 +3,7 @@
 public class OrderStatusNotificationService
 {
     // Locking manually because we need multiple values per key, and only need to lock very briefly
-    private readonly object _subscriptionsLock = new();
+    private readonly Lock _subscriptionsLock = new();
     private readonly Dictionary<string, HashSet<Subscription>> _subscriptionsByBuyerId = new();
 
     public IDisposable SubscribeToOrderStatusNotifications(string buyerId, Func<Task> callback)


### PR DESCRIPTION
Changed the type of _subscriptionsLock in OrderStatusNotificationService.cs from object to Lock for improved clarity and functionality in locking behavior.