### PR TITLE
feat: Add Multiple OpenAPI documents to the Scalar API Reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,6 +103,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="IdentityModel" Version="7.0.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.26"/>
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.1.0"/>
   </ItemGroup>
 </Project>

--- a/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
+++ b/src/eShop.ServiceDefaults/OpenApi.Extensions.cs
@@ -30,7 +30,7 @@ public static partial class Extensions
                 // Disable default fonts to avoid download unnecessary fonts
                 options.DefaultFonts = false;
             });
-            app.MapGet("/", () => Results.Redirect("/scalar/v1")).ExcludeFromDescription();
+            app.MapGet("/", () => Results.Redirect("/scalar/")).ExcludeFromDescription();
         }
 
         return app;
@@ -61,9 +61,11 @@ public static partial class Extensions
             string[] versions = ["v1", "v2"];
             foreach (var description in versions)
             {
+                var title = openApi.GetRequiredValue("Document:Title");
+                builder.Services.Configure<ScalarOptions>(options => options.AddDocument(description, $"{title} | {description}"));
                 builder.Services.AddOpenApi(description, options =>
                 {
-                    options.ApplyApiVersionInfo(openApi.GetRequiredValue("Document:Title"), openApi.GetRequiredValue("Document:Description"));
+                    options.ApplyApiVersionInfo(title, openApi.GetRequiredValue("Document:Description"));
                     options.ApplyAuthorizationChecks([.. scopes.Keys]);
                     options.ApplySecuritySchemeDefinitions();
                     options.ApplyOperationDeprecatedStatus();


### PR DESCRIPTION
Scalar now supports multiple OpenAPI documents.

This PR bumps the `Scalar.AspNetCore` package to version `2.1.0` and introduces adjustments to the OpenAPI extensions to support multiple documents.

This is how the UI now looks like for the services:

![image](https://github.com/user-attachments/assets/337f857d-7a81-4588-8102-cd50b013e2cf)

