### PR TITLE
Re-enable audience validation

### DIFF
--- a/src/eShop.ServiceDefaults/AuthenticationExtensions.cs
+++ b/src/eShop.ServiceDefaults/AuthenticationExtensions.cs
@@ -45,8 +45,6 @@ public static class AuthenticationExtensions
 #else
             options.TokenValidationParameters.ValidIssuers = [identityUrl];
 #endif
-            
-            options.TokenValidationParameters.ValidateAudience = false;
         });
 
         services.AddAuthorization();


### PR DESCRIPTION
Not sure why this was disabled in the first place...

This pull request includes a small change to AuthenticationExtensions.cs to remove the line that disables audience validation in token validation parameters.

@halter73 