### PR TITLE
Make login button text visible

### DIFF
--- a/src/Identity.API/wwwroot/css/site.css
+++ b/src/Identity.API/wwwroot/css/site.css
@@ -313,6 +313,7 @@ body {
     align-items: flex-end;
     gap: 8px;
     align-self: stretch;
+    color: #FFFFFF;
     background: #000;
 }
 


### PR DESCRIPTION
Set the "Login" button label color to white. This makes the button text visible on the black background.

Page URL: /Account/Login

Closes https://github.com/dotnet/eShop/issues/814