### PR TITLE
Change eShop version from .NET 9 to .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ A reference .NET application implementing an e-commerce website using a services
 ![eShop homepage screenshot](img/eshop_homepage.png)
 
 ## Getting Started
+> This version of eShop is based on .NET 10. See the project docs and the .NET 10 release notes for compatibility details.
 
-This version of eShop is based on .NET 9. 
+Last eShop versions:
+* [.NET 9.5 Aspire]
 
-Previous eShop versions:
+Previous eShop release versions:
 * [.NET 8](https://github.com/dotnet/eShop/tree/release/8.0)
 
 ### Prerequisites


### PR DESCRIPTION
What I changed:
- Replaced reference to .NET 9 in the README with .NET 10.

Notes for reviewers:
- This is a documentation-only change. -- I did a quick search for other ".NET 9" references — please double-check CI configs and global.json; if you want I can update them in the same PR (or open a follow-up PR).