### PR TITLE
Update .NET version from 9 to 10 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A reference .NET application implementing an e-commerce website using a services
 
 ## Getting Started
 
-This version of eShop is based on .NET 9. 
+This version of eShop is based on .NET 10. 
 
 Previous eShop versions:
 * [.NET 8](https://github.com/dotnet/eShop/tree/release/8.0)


### PR DESCRIPTION
What I changed:
- Replaced reference to .NET 9 in the README with .NET 10.

Notes for reviewers:
- This is a documentation-only change. -- I did a quick search for other ".NET 9" references — please double-check CI configs and global.json; if you want I can update them in the same PR (or open a follow-up PR).