### PR TITLE
Update in README eShop version from .NET 9 to .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ A reference .NET application implementing an e-commerce website using a services
 
 ## Getting Started
 
-This version of eShop is based on .NET 9. 
+> This version of eShop is based on .NET 10. See the project docs and the .NET 10 release notes for compatibility details.
 
-Previous eShop versions:
+Last eShop versions:
+* [.NET 9.5 Aspire]
+
+Previous eShop release versions:
 * [.NET 8](https://github.com/dotnet/eShop/tree/release/8.0)
-
 ### Prerequisites
 
 - Clone the eShop repository: https://github.com/dotnet/eshop
@@ -40,7 +42,7 @@ Or
 - From Dev Home go to `Machine Configuration -> Clone repositories`. Enter the URL for this repository. In the confirmation screen look for the section `Configuration File Detected` and click `Run File`.
 
 #### Mac, Linux, & Windows without Visual Studio
-- Install the latest [.NET 9 SDK](https://dot.net/download?cid=eshop)
+- Install the latest [.NET 10 SDK](https://dot.net/download?cid=eshop)
 
 Or
 


### PR DESCRIPTION
What I changed:
- Replaced reference to .NET 9 in the README with .NET 10.

Notes for reviewers:
- This is a documentation-only change.
- I did a quick search for other ".NET 9" references — please double-check CI configs and global.json; if you want I can update them in the same PR (or open a follow-up PR).