### PR TITLE
Remove unused dependencies from CreateOrderCommandHandler

### DIFF
--- a/src/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
+++ b/src/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
@@ -7,8 +7,6 @@ public class CreateOrderCommandHandler
     : IRequestHandler<CreateOrderCommand, bool>
 {
     private readonly IOrderRepository _orderRepository;
-    private readonly IIdentityService _identityService;
-    private readonly IMediator _mediator;
     private readonly IOrderingIntegrationEventService _orderingIntegrationEventService;
     private readonly ILogger<CreateOrderCommandHandler> _logger;
 
@@ -20,8 +18,6 @@ public class CreateOrderCommandHandler
         ILogger<CreateOrderCommandHandler> logger)
     {
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
-        _identityService = identityService ?? throw new ArgumentNullException(nameof(identityService));
-        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _orderingIntegrationEventService = orderingIntegrationEventService ?? throw new ArgumentNullException(nameof(orderingIntegrationEventService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }


### PR DESCRIPTION
Eliminated _identityService and _mediator fields and constructor parameters from CreateOrderCommandHandler, reducing unnecessary dependencies and simplifying the class.