### PR TITLE
Refactor Identity service and add unit tests for ProfileService

### DIFF
--- a/eShop.slnx
+++ b/eShop.slnx
@@ -1,4 +1,4 @@
-﻿<Solution>
+<Solution>
   <Folder Name="/src/">
     <Project Path="src/eShop.AppHost/eShop.AppHost.csproj" />
     <Project Path="src/Basket.API/Basket.API.csproj" />
@@ -23,6 +23,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/Basket.UnitTests/Basket.UnitTests.csproj" />
     <Project Path="tests/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj" />
+    <Project Path="tests/Identity.UnitTests/Identity.UnitTests.csproj" />
     <Project Path="tests/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj" />
     <Project Path="tests/Ordering.UnitTests/Ordering.UnitTests.csproj" />
     <Project Path="tests/ClientApp.UnitTests/ClientApp.UnitTests.csproj" />

--- a/src/Identity.API/Services/ProfileService.cs
+++ b/src/Identity.API/Services/ProfileService.cs
@@ -27,30 +27,35 @@
         {
             var subject = context.Subject ?? throw new ArgumentNullException(nameof(context.Subject));
 
-            var subjectId = subject.Claims.Where(x => x.Type == "sub").FirstOrDefault()?.Value;
+            var subjectId = subject.Claims.FirstOrDefault(x => x.Type == "sub")?.Value;
             var user = await _userManager.FindByIdAsync(subjectId);
 
-            context.IsActive = false;
-
-            if (user != null)
-            {
-                if (_userManager.SupportsUserSecurityStamp)
-                {
-                    var security_stamp = subject.Claims.Where(c => c.Type == "security_stamp").Select(c => c.Value).SingleOrDefault();
-                    if (security_stamp != null)
-                    {
-                        var db_security_stamp = await _userManager.GetSecurityStampAsync(user);
-                        if (db_security_stamp != security_stamp)
-                            return;
-                    }
-                }
-
-                context.IsActive =
-                    !user.LockoutEnabled ||
-                    !user.LockoutEnd.HasValue ||
-                    user.LockoutEnd <= DateTime.UtcNow;
-            }
+            context.IsActive = user != null
+                && await IsSecurityStampValidAsync(user, subject)
+                && IsNotLockedOut(user);
         }
+
+        private async Task<bool> IsSecurityStampValidAsync(ApplicationUser user, ClaimsPrincipal subject)
+        {
+            if (!_userManager.SupportsUserSecurityStamp)
+                return true;
+
+            var tokenStamp = subject.Claims
+                .Where(c => c.Type == "security_stamp")
+                .Select(c => c.Value)
+                .SingleOrDefault();
+
+            if (tokenStamp == null)
+                return true;
+
+            var dbStamp = await _userManager.GetSecurityStampAsync(user);
+            return dbStamp == tokenStamp;
+        }
+
+        private static bool IsNotLockedOut(ApplicationUser user) =>
+            !user.LockoutEnabled ||
+            !user.LockoutEnd.HasValue ||
+            user.LockoutEnd <= DateTime.UtcNow;
 
         private IEnumerable<Claim> GetClaimsFromUser(ApplicationUser user)
         {

--- a/tests/Identity.UnitTests/GlobalUsings.cs
+++ b/tests/Identity.UnitTests/GlobalUsings.cs
@@ -1,0 +1,14 @@
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Security.Claims;
+global using System.Threading.Tasks;
+global using Duende.IdentityServer.Models;
+global using Duende.IdentityServer.Validation;
+global using eShop.Identity.API.Models;
+global using eShop.Identity.API.Services;
+global using Microsoft.AspNetCore.Identity;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;
+global using NSubstitute;
+
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]

--- a/tests/Identity.UnitTests/Identity.UnitTests.csproj
+++ b/tests/Identity.UnitTests/Identity.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="MSTest.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
+    <IsPublishable>false</IsPublishable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Identity.API\Identity.API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Identity.UnitTests/Services/ProfileServiceTests.cs
+++ b/tests/Identity.UnitTests/Services/ProfileServiceTests.cs
@@ -1,0 +1,154 @@
+namespace eShop.Identity.UnitTests.Services;
+
+[TestClass]
+public class ProfileServiceTests
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly ProfileService _profileService;
+
+    public ProfileServiceTests()
+    {
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        _userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        _profileService = new ProfileService(_userManager);
+    }
+
+    private static IsActiveContext CreateContext(string subjectId, IEnumerable<Claim>? extraClaims = null)
+    {
+        var claims = new List<Claim> { new Claim("sub", subjectId) };
+        if (extraClaims != null)
+            claims.AddRange(extraClaims);
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+        return new IsActiveContext(principal, new Client(), "test");
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserNotFound_SetsIsActiveFalse()
+    {
+        var context = CreateContext("unknown-id");
+        _userManager.FindByIdAsync("unknown-id").Returns((ApplicationUser)null!);
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsFalse(context.IsActive);
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserFound_SecurityStampNotSupported_NotLockedOut_SetsIsActiveTrue()
+    {
+        var user = new ApplicationUser { Id = "user-1", LockoutEnabled = false };
+        var context = CreateContext("user-1");
+
+        _userManager.FindByIdAsync("user-1").Returns(user);
+        _userManager.SupportsUserSecurityStamp.Returns(false);
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsTrue(context.IsActive);
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserFound_SecurityStampInToken_Matches_NotLockedOut_SetsIsActiveTrue()
+    {
+        var user = new ApplicationUser { Id = "user-1", LockoutEnabled = false };
+        var context = CreateContext("user-1", [new Claim("security_stamp", "stamp-abc")]);
+
+        _userManager.FindByIdAsync("user-1").Returns(user);
+        _userManager.SupportsUserSecurityStamp.Returns(true);
+        _userManager.GetSecurityStampAsync(user).Returns("stamp-abc");
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsTrue(context.IsActive);
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserFound_SecurityStampInToken_Mismatches_SetsIsActiveFalse()
+    {
+        var user = new ApplicationUser { Id = "user-1", LockoutEnabled = false };
+        var context = CreateContext("user-1", [new Claim("security_stamp", "old-stamp")]);
+
+        _userManager.FindByIdAsync("user-1").Returns(user);
+        _userManager.SupportsUserSecurityStamp.Returns(true);
+        _userManager.GetSecurityStampAsync(user).Returns("new-stamp");
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsFalse(context.IsActive);
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserFound_NoSecurityStampInToken_SkipsStampCheck_SetsIsActiveTrue()
+    {
+        var user = new ApplicationUser { Id = "user-1", LockoutEnabled = false };
+        var context = CreateContext("user-1"); // no security_stamp claim
+
+        _userManager.FindByIdAsync("user-1").Returns(user);
+        _userManager.SupportsUserSecurityStamp.Returns(true);
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsTrue(context.IsActive);
+        await _userManager.DidNotReceive().GetSecurityStampAsync(Arg.Any<ApplicationUser>());
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserFound_ValidStamp_CurrentlyLockedOut_SetsIsActiveFalse()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "user-1",
+            LockoutEnabled = true,
+            LockoutEnd = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        var context = CreateContext("user-1");
+
+        _userManager.FindByIdAsync("user-1").Returns(user);
+        _userManager.SupportsUserSecurityStamp.Returns(false);
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsFalse(context.IsActive);
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserFound_ValidStamp_LockoutExpired_SetsIsActiveTrue()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "user-1",
+            LockoutEnabled = true,
+            LockoutEnd = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+        var context = CreateContext("user-1");
+
+        _userManager.FindByIdAsync("user-1").Returns(user);
+        _userManager.SupportsUserSecurityStamp.Returns(false);
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsTrue(context.IsActive);
+    }
+
+    [TestMethod]
+    public async Task IsActiveAsync_UserFound_ValidStamp_LockoutEnabledWithNoEndDate_SetsIsActiveTrue()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "user-1",
+            LockoutEnabled = true,
+            LockoutEnd = null
+        };
+        var context = CreateContext("user-1");
+
+        _userManager.FindByIdAsync("user-1").Returns(user);
+        _userManager.SupportsUserSecurityStamp.Returns(false);
+
+        await _profileService.IsActiveAsync(context);
+
+        Assert.IsTrue(context.IsActive);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new unit test project for the Identity API and refactors the `ProfileService` to improve testability and logic clarity. The most significant changes are the addition of comprehensive unit tests for user activity checks, restructuring of the `IsActiveAsync` method, and the inclusion of the new test project in the solution.

**Testing improvements:**

* Added a new test project `Identity.UnitTests` with a full suite of unit tests for the `ProfileService`, covering scenarios like user not found, security stamp validation, and lockout status. (`tests/Identity.UnitTests/Identity.UnitTests.csproj`, `tests/Identity.UnitTests/Services/ProfileServiceTests.cs`, [[1]](diffhunk://#diff-3dadc3bc80daefa7a0abf12069a3fa898e89574acf0c6e78feacf05d468bc304R1-R24) [[2]](diffhunk://#diff-a656d12725fc7249109a4dfcd7711263adbc6efe8c06c4c97baed880fe4d72abR1-R154)
* Created a global usings file to streamline imports and enabled parallel test execution for faster test runs. (`tests/Identity.UnitTests/GlobalUsings.cs`, [tests/Identity.UnitTests/GlobalUsings.csR1-R14](diffhunk://#diff-05063322af0691edc04505294c8127b1f16310c62f9ceeaac02877d975898dc5R1-R14))

**ProfileService refactoring:**

* Refactored `IsActiveAsync` in `ProfileService` to simplify logic and improve readability, extracting security stamp and lockout checks into dedicated helper methods. (`src/Identity.API/Services/ProfileService.cs`, [src/Identity.API/Services/ProfileService.csL30-L53](diffhunk://#diff-83ab77aaa66097043c4a71b8210339b6f35449bf268aace8436e5a7c87d9343cL30-L53))

**Solution structure:**

* Added the new `Identity.UnitTests` project to the solution file, ensuring it's included in builds and test runs. (`eShop.slnx`, [eShop.slnxR26](diffhunk://#diff-aae7c2ed69322925d661476b74c2a2521a6458f664be8bc7173ffd2fe29fbfd9R26))

These changes enhance test coverage for Identity API user activity logic and make the codebase easier to maintain and extend.