### PR TITLE
docs: add scoped agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# Copilot Instructions for eShop
+
+Start with [AGENTS.md](../AGENTS.md), then follow the nearest scoped `AGENTS.md` for the files being changed.
+
+## Copilot-Specific Guidance
+
+- Prefer the scoped AGENTS files over duplicating context in this file; they are the project index for future sessions.
+- For tests, use `dotnet test --project <test-project.csproj>`; bare test directory paths fail in this repo.
+- When changing integration events, check every service-local copy of the event contract, not just the publisher.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# eShop - Agent Index
+
+Use this file for repo-wide context. Read the nearest scoped `AGENTS.md` before changing code in that area:
+
+- `src\AGENTS.md` - shared service, AppHost, event bus, package rules
+- `src\eShop.AppHost\AGENTS.md` - Aspire orchestration, resource names, AI toggles
+- `src\Ordering.API\AGENTS.md` and `src\Ordering.Domain\AGENTS.md` - Ordering CQRS/DDD flow
+- `src\Catalog.API\AGENTS.md`, `src\Basket.API\AGENTS.md`, `src\WebApp\AGENTS.md` - service-specific rules
+- `tests\AGENTS.md` and `e2e\AGENTS.md` - test harness specifics
+
+## Verified command gotchas
+
+- Run the app from the repo root: `dotnet run --project src\eShop.AppHost\eShop.AppHost.csproj` (requires Docker).
+- This repo uses Microsoft.Testing.Platform. Use `dotnet test --project <path-to-csproj>` or `--solution eShop.slnx`; bare directory paths such as `dotnet test tests\Ordering.UnitTests` fail.
+- Fast unit-test validation:
+  - `dotnet test --project tests\Ordering.UnitTests\Ordering.UnitTests.csproj`
+  - `dotnet test --project tests\Basket.UnitTests\Basket.UnitTests.csproj`
+  - Single test: `dotnet test --project tests\Ordering.UnitTests\Ordering.UnitTests.csproj --filter "FullyQualifiedName~CreateOrderCommandHandlerTest"`
+- Functional tests spin up Aspire resources/containers; check Docker/container startup before treating a slow full-solution test run as a code failure.
+- Playwright defaults to `http://localhost:5045`; logged-in tests require `USERNAME1` and `PASSWORD`.
+
+## Repo-wide facts
+
+- `src\eShop.AppHost` wires Redis, RabbitMQ, PostgreSQL/pgvector, APIs, workers, and the Blazor frontend.
+- Central NuGet versions live in `Directory.Packages.props`; do not add versions in project files.
+- `TreatWarningsAsErrors` and `UseArtifactsOutput` are enabled globally.
+- Services communicate through Aspire service discovery (HTTP/gRPC) and RabbitMQ integration events; EF-backed services use an outbox (`IntegrationEventLogEF`) when data changes publish events.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,7 @@
+# E2E Rules
+
+- Playwright config is `playwright.config.ts`; `webServer` starts AppHost and waits for `http://localhost:5045`.
+- CI uses one worker, retries twice, and has a longer web-server timeout.
+- Logged-in tests depend on `login.setup.ts`, which writes storage state to `playwright\.auth\user.json`.
+- Login setup requires `USERNAME1` and `PASSWORD` from `.env` or process environment.
+- Current project split: setup, logged-in cart tests (`AddItemTest`, `RemoveItemTest`), and anonymous browsing (`BrowseItemTest`).

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,10 @@
+# Source Project Rules
+
+- Executable services start with `builder.AddServiceDefaults()`. API projects usually follow `AddApplicationServices()` -> `MapDefaultEndpoints()` -> API route mapping -> `UseDefaultOpenApi()`.
+- Register new services and infrastructure in `src\eShop.AppHost\Program.cs`; use `WithReference(...)` and `WaitFor(...)` to model dependencies.
+- Service-discovery clients use Aspire names, e.g. `https+http://catalog-api`, `https+http://ordering-api`, and gRPC `http://basket-api`.
+- Event contracts are intentionally copied into each participating service's `IntegrationEvents\Events` folder. If an event payload changes, update every local copy and every handler that consumes it.
+- Event handlers live in `IntegrationEvents\EventHandling` and must be registered with `AddSubscription<,>()` in that service's `AddApplicationServices()` or `AddEventBusSubscriptions()`.
+- Projects that already configure event JSON source generation (`Basket.API`, `OrderProcessor`) need matching `[JsonSerializable]` entries and `ConfigureJsonOptions(...)` when new event types are added.
+- EF-backed services use `AddMigration<TContext, TSeed>()` for startup migration/seeding.
+- Do not add NuGet versions to `.csproj` files; add or update versions in `Directory.Packages.props`.

--- a/src/Basket.API/AGENTS.md
+++ b/src/Basket.API/AGENTS.md
@@ -1,0 +1,6 @@
+# Basket.API Rules
+
+- Basket is gRPC-first: service implementation is in `Grpc\BasketService.cs`, contract in `Proto`, and WebApp consumes the generated `Basket.BasketClient`.
+- Basket state is persisted through `IBasketRepository`/`RedisBasketRepository`; keep Redis access behind that repository.
+- Basket consumes `OrderStartedIntegrationEvent` to clear baskets after checkout. Update the subscription and `IntegrationEventContext` JSON source generation when adding consumed event types.
+- Authentication is added in `AddApplicationServices()` with `AddDefaultAuthentication()`; keep auth concerns out of the gRPC service methods unless a method needs user-specific behavior.

--- a/src/Catalog.API/AGENTS.md
+++ b/src/Catalog.API/AGENTS.md
@@ -1,0 +1,7 @@
+# Catalog.API Rules
+
+- Endpoints live in `Apis\CatalogApi.cs` as versioned Minimal API route groups. New routes should include route name, summary, description, and tags like the existing endpoints.
+- Keep `builder.Environment.IsBuild()` handling in `Extensions.AddApplicationServices()`; build-time OpenAPI generation must not require database configuration or migrations.
+- Catalog uses PostgreSQL with pgvector. Embeddings are enabled by either `OllamaEnabled=true` or a `textEmbeddingModel` connection string; AI work should go through `ICatalogAI`.
+- Catalog consumes order-status events to validate stock and publishes stock/price events through `CatalogIntegrationEventService`.
+- When a catalog data change publishes an event, use `SaveEventAndCatalogContextChangesAsync(...)` so the catalog update and outbox entry stay atomic.

--- a/src/Ordering.API/AGENTS.md
+++ b/src/Ordering.API/AGENTS.md
@@ -1,0 +1,9 @@
+# Ordering.API Rules
+
+- Endpoints in `Apis\OrdersApi.cs` are thin Minimal API handlers. Keep authorization at the route group (`RequireAuthorization()` in `Program.cs`) and use `[AsParameters] OrderServices` for shared dependencies.
+- Commands live in `Application\Commands` as command + handler pairs. Add a FluentValidation validator when command inputs have business rules.
+- Mutating endpoints that accept `x-requestid` wrap commands in `IdentifiedCommand<TCommand, bool>` for idempotency; keep that pattern for new mutating order operations.
+- MediatR pipeline order is logging -> validation -> transaction. `TransactionBehavior` commits the EF transaction, then publishes pending outbox events via `IOrderingIntegrationEventService`.
+- Do not publish RabbitMQ events directly from command handlers; enqueue via the existing integration-event service/outbox pattern.
+- Read-side models and Dapper queries live in `Application\Queries`; do not expose domain entities as query DTOs.
+- Inbound event subscriptions are centralized in `Extensions.AddEventBusSubscriptions()`.

--- a/src/Ordering.Domain/AGENTS.md
+++ b/src/Ordering.Domain/AGENTS.md
@@ -1,0 +1,7 @@
+# Ordering.Domain Rules
+
+- Keep behavior inside aggregates. State changes should go through aggregate methods, not public setters or external mutation.
+- `Order` owns its item collection through a private `List<OrderItem>` and exposes `IReadOnlyCollection<OrderItem>`; preserve that encapsulation pattern for aggregate collections.
+- Domain entities raise MediatR `INotification` domain events through `AddDomainEvent(...)`. Mapping domain events to integration events belongs in `Ordering.API`, not the domain project.
+- EF needs protected/private constructors and private setters; do not widen visibility just to make tests easier.
+- Invalid status transitions should fail through the existing domain exception pattern instead of silently no-oping.

--- a/src/WebApp/AGENTS.md
+++ b/src/WebApp/AGENTS.md
@@ -1,0 +1,7 @@
+# WebApp Rules
+
+- This is the Blazor Server frontend. API clients are registered in `Extensions.AddApplicationServices()` using Aspire service-discovery addresses.
+- AppHost injects `IdentityUrl` and `CallBackUrl`; authentication/OIDC setup is centralized in `AddAuthenticationServices()`.
+- Basket uses the generated gRPC client for `basket-api`; catalog and ordering use typed HTTP clients with API versioning and auth token forwarding.
+- Order status UI updates come from RabbitMQ handlers under `Services\OrderStatus\IntegrationEvents` and flow through `OrderStatusNotificationService`.
+- Chat/AI is optional: WebApp uses `chatModel` or `OllamaEnabled=true`, then enables function invocation on the chat client.

--- a/src/eShop.AppHost/AGENTS.md
+++ b/src/eShop.AppHost/AGENTS.md
@@ -1,0 +1,8 @@
+# AppHost Rules
+
+- Resource names are part of service configuration: `redis`, `eventbus`, `postgres`; databases `catalogdb`, `identitydb`, `orderingdb`; projects `identity-api`, `basket-api`, `catalog-api`, `ordering-api`, `order-processor`, `payment-processor`, `webapp`.
+- When adding a dependency, wire both sides: AppHost `WithReference(...)`/`WaitFor(...)` and the target service's matching connection/client registration.
+- Workers can depend on APIs that own migrations; `OrderProcessor` waits for `ordering-api` because Ordering applies EF migrations.
+- `ESHOP_USE_HTTP_ENDPOINTS=1` forces HTTP endpoints for tests/CI through `ShouldUseHttpForEndpoints()`.
+- `AddForwardedHeaders()` injects `ASPNETCORE_FORWARDEDHEADERS_ENABLED=true` into all project resources.
+- AI is opt-in through local booleans in `Program.cs`: `AddOpenAI(...)` injects `textEmbeddingModel` into Catalog and `chatModel` into WebApp; `AddOllama(...)` injects `embedding` and `chat` plus `OllamaEnabled=true`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,7 @@
+# Test Rules
+
+- Unit tests use MSTest and NSubstitute. Ordering tests use builders in `tests\Ordering.UnitTests\Builders.cs`.
+- Use `dotnet test --project <test-project.csproj>`; directory paths fail under Microsoft.Testing.Platform in this repo.
+- Functional tests use Aspire `DistributedApplication` fixtures plus `WebApplicationFactory`; they require Docker and may start PostgreSQL/Identity resources.
+- Ordering functional tests inject `AutoAuthorizeMiddleware` instead of using real auth.
+- Use filters for single-test runs, e.g. `--filter "FullyQualifiedName~CreateOrderCommandHandlerTest"`.


### PR DESCRIPTION
## Summary
- Add a concise root AGENTS.md as an index for future AI/agent sessions
- Add scoped AGENTS.md files for source services, tests, and e2e guidance
- Add Copilot instructions that point to the root/scoped agent guidance

## Notes
- Captures repo-specific gotchas around Microsoft.Testing.Platform, Aspire orchestration, service-local integration event contracts, and service-specific patterns.
- Requested review from @adityamandaleeka as the top non-bot contributor shown for the source repository.

## Validation
- dotnet build eShop.slnx
- dotnet test --project tests/Ordering.UnitTests/Ordering.UnitTests.csproj
- dotnet test --project tests/Basket.UnitTests/Basket.UnitTests.csproj