### PR TITLE
Fix inaccurate comment in SaveEntitiesAsync

### DIFF
--- a/src/Ordering.Infrastructure/OrderingContext.cs
+++ b/src/Ordering.Infrastructure/OrderingContext.cs
@@ -54,7 +54,8 @@ public class OrderingContext : DbContext, IUnitOfWork
         //    Domain event handlers run while changes are still pending in the ChangeTracker.
         //    Handlers may call SaveEntitiesAsync themselves, producing multiple intermediate flushes,
         //    all within the same explicit transaction. The final SaveChanges below flushes any remaining changes.
-        //    Requires client-side ID generation (e.g. HiLo) if handlers depend on DB-generated IDs.
+        //    If handlers depend on DB-generated IDs, they must either use client-side ID generation
+        //    (for example, HiLo) or perform an intermediate SaveChanges/SaveEntitiesAsync flush first.
         //
         // B) Dispatch AFTER SaveChanges:
         //    Handlers run after the original changes have been flushed, and because they execute within the

--- a/src/Ordering.Infrastructure/OrderingContext.cs
+++ b/src/Ordering.Infrastructure/OrderingContext.cs
@@ -46,12 +46,20 @@ public class OrderingContext : DbContext, IUnitOfWork
 
     public async Task<bool> SaveEntitiesAsync(CancellationToken cancellationToken = default)
     {
-        // Dispatch Domain Events collection. 
-        // Choices:
-        // A) Right BEFORE committing data (EF SaveChanges) into the DB will make a single transaction including  
-        // side effects from the domain event handlers which are using the same DbContext with "InstancePerLifetimeScope" or "scoped" lifetime
-        // B) Right AFTER committing data (EF SaveChanges) into the DB will make multiple transactions. 
-        // You will need to handle eventual consistency and compensatory actions in case of failures in any of the Handlers. 
+        // Dispatch Domain Events collection.
+        // Note: commands are wrapped in an explicit transaction by TransactionBehavior, so both orderings
+        // below result in a single database transaction. The real trade-off is:
+        //
+        // A) Dispatch BEFORE SaveChanges (current approach):
+        //    Domain event handlers run while changes are still pending in the ChangeTracker.
+        //    All handler side-effects and the original command changes are flushed together in one SaveChanges call.
+        //    Requires client-side ID generation (e.g. HiLo) if handlers depend on DB-generated IDs.
+        //
+        // B) Dispatch AFTER SaveChanges:
+        //    The explicit transaction uses ReadCommitted isolation (see BeginTransactionAsync), so handlers
+        //    can observe the already-flushed state via SQL queries within the same transaction.
+        //    DB-generated IDs are available. Handler side-effects are flushed in their own SaveChanges calls,
+        //    still within the same explicit transaction opened by TransactionBehavior.
         await _mediator.DispatchDomainEventsAsync(this);
 
         // After executing this line all the changes (from the Command Handler and Domain Event Handlers) 

--- a/src/Ordering.Infrastructure/OrderingContext.cs
+++ b/src/Ordering.Infrastructure/OrderingContext.cs
@@ -56,8 +56,9 @@ public class OrderingContext : DbContext, IUnitOfWork
         //    Requires client-side ID generation (e.g. HiLo) if handlers depend on DB-generated IDs.
         //
         // B) Dispatch AFTER SaveChanges:
-        //    The explicit transaction uses ReadCommitted isolation (see BeginTransactionAsync), so handlers
-        //    can observe the already-flushed state via SQL queries within the same transaction.
+        //    Handlers run after the original changes have been flushed, and because they execute within the
+        //    same explicit transaction they can observe that already-flushed state via SQL queries.
+        //    The transaction is created with ReadCommitted isolation (see BeginTransactionAsync).
         //    DB-generated IDs are available. Handler side-effects are flushed in their own SaveChanges calls,
         //    still within the same explicit transaction opened by TransactionBehavior.
         await _mediator.DispatchDomainEventsAsync(this);

--- a/src/Ordering.Infrastructure/OrderingContext.cs
+++ b/src/Ordering.Infrastructure/OrderingContext.cs
@@ -52,7 +52,8 @@ public class OrderingContext : DbContext, IUnitOfWork
         //
         // A) Dispatch BEFORE SaveChanges (current approach):
         //    Domain event handlers run while changes are still pending in the ChangeTracker.
-        //    All handler side-effects and the original command changes are flushed together in one SaveChanges call.
+        //    Handlers may call SaveEntitiesAsync themselves, producing multiple intermediate flushes,
+        //    all within the same explicit transaction. The final SaveChanges below flushes any remaining changes.
         //    Requires client-side ID generation (e.g. HiLo) if handlers depend on DB-generated IDs.
         //
         // B) Dispatch AFTER SaveChanges:


### PR DESCRIPTION
The original comment claimed that dispatching domain events AFTER SaveChanges (option B) would result in multiple transactions. This was true before TransactionBehavior was introduced, but since TransactionBehavior wraps the entire command handler in an explicit transaction, both orderings now result in a single database transaction.

Update the comment to accurately describe the real trade-off between the two approaches, and note that the explicit transaction uses ReadCommitted isolation (see BeginTransactionAsync), which means handlers in option B can observe already-flushed state via SQL queries within the same transaction.