### PR TITLE
Remove CVV (card security number) from JWT claims

### DIFF
--- a/src/ClientApp/Models/User/UserInfo.cs
+++ b/src/ClientApp/Models/User/UserInfo.cs
@@ -17,8 +17,8 @@ public class UserInfo
 
     [JsonPropertyName("card_holder")] public string CardHolder { get; set; }
 
-    [JsonPropertyName("card_security_number")]
-    public string CardSecurityNumber { get; set; }
+    // CVV (card security number) is deliberately absent: it must never be carried
+    // by identity claims. It is collected at payment time, not sourced from the token.
 
     [JsonPropertyName("address_city")] public string Address { get; set; }
 

--- a/src/ClientApp/Services/Identity/IdentityMockService.cs
+++ b/src/ClientApp/Services/Identity/IdentityMockService.cs
@@ -33,7 +33,6 @@ public class IdentityMockService : IIdentityService
             LastName = "User",
             CardNumber = "XXXXXXXXXXXX3456",
             CardHolder = "Sample User",
-            CardSecurityNumber = "123",
             Address = "123 Sample Street",
             Country = "USA",
             State = "Washington",

--- a/src/ClientApp/Services/Identity/IdentityService.cs
+++ b/src/ClientApp/Services/Identity/IdentityService.cs
@@ -84,8 +84,6 @@ public class IdentityService : IIdentityService
                 LastName = userInfoWithClaims.Claims.FirstOrDefault(c => c.Type == "last_name")?.Value,
                 CardNumber = userInfoWithClaims.Claims.FirstOrDefault(c => c.Type == "card_number")?.Value,
                 CardHolder = userInfoWithClaims.Claims.FirstOrDefault(c => c.Type == "card_holder")?.Value,
-                CardSecurityNumber =
-                    userInfoWithClaims.Claims.FirstOrDefault(c => c.Type == "card_security_number")?.Value,
                 PhoneNumberVerified =
                     bool.Parse(userInfoWithClaims.Claims.FirstOrDefault(c => c.Type == "phone_number_verified")
                         ?.Value ?? "false"),

--- a/src/ClientApp/ViewModels/CheckoutViewModel.cs
+++ b/src/ClientApp/ViewModels/CheckoutViewModel.cs
@@ -61,7 +61,9 @@ public partial class CheckoutViewModel : ViewModelBase
                     CardNumber = userInfo?.CardNumber,
                     CardHolderName = userInfo?.CardHolder,
                     CardType = new CardType {Id = 3, Name = "MasterCard"},
-                    SecurityNumber = userInfo?.CardSecurityNumber
+                    // CVV is never sourced from identity. This sample has no real payment
+                    // capture, so a placeholder is sent (mirrors WebApp BasketState).
+                    SecurityNumber = "111"
                 };
 
                 var orderItems = CreateOrderItems(basketItems);

--- a/src/Identity.API/Services/ProfileService.cs
+++ b/src/Identity.API/Services/ProfileService.cs
@@ -73,8 +73,9 @@
             if (!string.IsNullOrWhiteSpace(user.CardHolderName))
                 claims.Add(new Claim("card_holder", user.CardHolderName));
 
-            if (!string.IsNullOrWhiteSpace(user.SecurityNumber))
-                claims.Add(new Claim("card_security_number", user.SecurityNumber));
+            // CVV (card security number) is intentionally NOT issued as a JWT claim.
+            // PCI-DSS prohibits storing/transmitting the security code; it must be
+            // collected from the user at payment time, never sourced from the token.
 
             if (!string.IsNullOrWhiteSpace(user.Expiration))
                 claims.Add(new Claim("card_expiration", user.Expiration));


### PR DESCRIPTION
Identity.API ProfileService stamped the card security number into every issued JWT as the `card_security_number` claim, exposing CVV in transit and at rest on every request — a critical PCI-DSS violation.

- Identity.API: stop issuing the card_security_number claim.
- ClientApp: stop sourcing CVV from identity claims. Remove UserInfo.CardSecurityNumber and send a placeholder at order time, mirroring the WebApp checkout (this sample has no real payment capture).

Fixes OPLANE_REQ-00077210.