### PR TITLE
Fix AddNewOrder test validation and integration event discovery

### DIFF
--- a/src/Catalog.API/Extensions/Extensions.cs
+++ b/src/Catalog.API/Extensions/Extensions.cs
@@ -24,7 +24,11 @@ public static class Extensions
         builder.Services.AddMigration<CatalogContext, CatalogContextSeed>();
 
         // Add the integration services that consume the DbContext
-        builder.Services.AddTransient<IIntegrationEventLogService, IntegrationEventLogService<CatalogContext>>();
+        // Pass this project's assembly so the integration event types can be resolved for deserialization. Using the entry assembly breaks under functional tests, where the entry assembly is the test host and does not contain the derived IntegrationEvent types.
+        builder.Services.AddTransient<IIntegrationEventLogService>(sp =>
+            new IntegrationEventLogService<CatalogContext>(
+                sp.GetRequiredService<CatalogContext>(),
+                typeof(Extensions).Assembly));
 
         builder.Services.AddTransient<ICatalogIntegrationEventService, CatalogIntegrationEventService>();
 

--- a/src/IntegrationEventLogEF/Services/IntegrationEventLogService.cs
+++ b/src/IntegrationEventLogEF/Services/IntegrationEventLogService.cs
@@ -7,10 +7,10 @@ public class IntegrationEventLogService<TContext> : IIntegrationEventLogService,
     private readonly TContext _context;
     private readonly Type[] _eventTypes;
 
-    public IntegrationEventLogService(TContext context)
+    public IntegrationEventLogService(TContext context, Assembly eventTypesAssembly)
     {
         _context = context;
-        _eventTypes = Assembly.Load(Assembly.GetEntryAssembly().FullName)
+        _eventTypes = eventTypesAssembly
             .GetTypes()
             .Where(t => t.Name.EndsWith(nameof(IntegrationEvent)))
             .ToArray();

--- a/src/Ordering.API/Apis/OrdersApi.cs
+++ b/src/Ordering.API/Apis/OrdersApi.cs
@@ -157,13 +157,11 @@ public static class OrdersApi
             if (result)
             {
                 services.Logger.LogInformation("CreateOrderCommand succeeded - RequestId: {RequestId}", requestId);
-            }
-            else
-            {
-                services.Logger.LogWarning("CreateOrderCommand failed - RequestId: {RequestId}", requestId);
+                return TypedResults.Ok();
             }
 
-            return TypedResults.Ok();
+            services.Logger.LogWarning("CreateOrderCommand failed - RequestId: {RequestId}", requestId);
+            return TypedResults.BadRequest("Create order failed to process.");
         }
     }
 }

--- a/src/Ordering.API/Extensions/Extensions.cs
+++ b/src/Ordering.API/Extensions/Extensions.cs
@@ -21,7 +21,11 @@ internal static class Extensions
         services.AddMigration<OrderingContext, OrderingContextSeed>();
 
         // Add the integration services that consume the DbContext
-        services.AddTransient<IIntegrationEventLogService, IntegrationEventLogService<OrderingContext>>();
+        // Pass this project's assembly so the integration event types can be resolved for deserialization. Using the entry assembly breaks under functional tests, where the entry assembly is the test host and does not contain the derived IntegrationEvent types.
+        services.AddTransient<IIntegrationEventLogService>(sp =>
+            new IntegrationEventLogService<OrderingContext>(
+                sp.GetRequiredService<OrderingContext>(),
+                typeof(Extensions).Assembly));
 
         services.AddTransient<IOrderingIntegrationEventService, OrderingIntegrationEventService>();
 

--- a/tests/Ordering.FunctionalTests/OrderingApiTests.cs
+++ b/tests/Ordering.FunctionalTests/OrderingApiTests.cs
@@ -133,7 +133,7 @@ public sealed class OrderingApiTests : IClassFixture<OrderingApiFixture>
     }
 
     [Fact]
-    public async Task AddNewOrder()
+    public async Task AddNewOrderWithInvalidDataFails()
     {
         // Act
         var item = new BasketItem
@@ -154,8 +154,32 @@ public sealed class OrderingApiTests : IClassFixture<OrderingApiFixture>
         };
         var response = await _httpClient.PostAsync("api/orders", content, TestContext.Current.CancellationToken);
         var s = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-
         // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddNewOrder()
+    {
+        // Act
+        var item = new BasketItem
+        {
+            Id = "1",
+            ProductId = 12,
+            ProductName = "Test",
+            UnitPrice = 10,
+            OldUnitPrice = 9,
+            Quantity = 1,
+            PictureUrl = null
+        };
+        var cardExpirationDate = Convert.ToDateTime("2123-12-22T12:34:24.334Z").ToUniversalTime();
+        var OrderRequest = new CreateOrderRequest("1", "TestUser", "Istanbul", "Kadikoy", "IS", "TR", "34034", "XXXXXXXXXXXX0005", "test buyer", cardExpirationDate, "123", 1, null, new List<BasketItem> { item });
+        var content = new StringContent(JsonSerializer.Serialize(OrderRequest), UTF8Encoding.UTF8, "application/json")
+        {
+            Headers = { { "x-requestid", Guid.NewGuid().ToString() } }
+        };
+        var response = await _httpClient.PostAsync("api/orders", content, TestContext.Current.CancellationToken);
+        var s = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 


### PR DESCRIPTION
Fixes #943

## Problem

The `AddNewOrder` functional test in `Ordering.FunctionalTests` passed even though the
order was never actually created. Issue #943 identified three underlying problems:

1. **Validation failures were masked.** `CreateOrderAsync` always returned `200 OK`, even
   when the command failed, so an invalid request looked successful.
2. **`DateTime.Kind` mismatch.** The test built the card expiration date with
   `Convert.ToDateTime(...)`, producing `Kind.Local`, which Npgsql rejects for
   `timestamp with time zone` columns.
3. **Integration event types could not be resolved under tests.**
   `IntegrationEventLogService` loaded event types from `Assembly.GetEntryAssembly()`.
   In functional tests the entry assembly is the test host, which does not contain the
   derived `IntegrationEvent` types, so publishing an order's integration event threw and
   returned `500`.

## Changes

- **`OrdersApi.CreateOrderAsync`**: now returns `BadRequest` when the command fails,
  consistent with the `Cancel`/`Ship` endpoints, instead of always returning `Ok`.
- **`IntegrationEventLogService`**: the assembly to scan for event types is now injected
  via the constructor instead of relying on the entry assembly.
- **`Ordering.API` / `Catalog.API` DI registration**: each API now passes its own
  assembly (`typeof(Extensions).Assembly`) when registering the log service.
- **`OrderingApiTests`**:
  - Renamed the existing invalid-data test to `AddNewOrderWithInvalidDataFails`
    (asserts `BadRequest`).
  - Added a new `AddNewOrder` test using valid data (future UTC expiration date, complete
    address, valid security number) that asserts `OK`.

## Testing

- `Ordering.FunctionalTests`: 12/12 passing
- `Ordering.UnitTests`: 41/41 passing