### PR TITLE
Upgrade Aspire to 13.5.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <DotnetPackagesVersion>10.0.8</DotnetPackagesVersion>
+    <DotnetPackagesVersion>10.0.11</DotnetPackagesVersion>
     <MicrosoftExtensionsVersion>10.4.0</MicrosoftExtensionsVersion>
-    <AspireVersion>13.4.6</AspireVersion>
-    <AspireUnstablePackagesVersion>13.4.6-preview.1.26319.6</AspireUnstablePackagesVersion>
+    <AspireVersion>13.5.3</AspireVersion>
+    <AspireUnstablePackagesVersion>13.5.3-preview.1.26425.3</AspireUnstablePackagesVersion>
     <GrpcVersion>2.80.0</GrpcVersion>
     <DuendeVersion>7.3.1</DuendeVersion>
     <ApiVersioningVersion>10.0.0-preview.2</ApiVersioningVersion>
@@ -40,7 +40,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(DotnetPackagesVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="$(DotnetPackagesVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="$(DotnetPackagesVersion)" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="MSTest" Version="4.0.2" />
     <!-- Version together with EF -->
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />

--- a/src/eShop.AppHost/eShop.AppHost.csproj
+++ b/src/eShop.AppHost/eShop.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.3">
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/tests/Basket.FunctionalTests/Basket.FunctionalTests.csproj
+++ b/tests/Basket.FunctionalTests/Basket.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
+++ b/tests/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
+++ b/tests/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/Webhooks.FunctionalTests/Webhooks.FunctionalTests.csproj
+++ b/tests/Webhooks.FunctionalTests/Webhooks.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>


### PR DESCRIPTION
## Summary
- upgrade stable Aspire packages and all AppHost SDK declarations to 13.5.3
- update preview-only Aspire integrations to the matching 13.5.3 preview build
- align .NET and OpenAPI package floors required by Aspire 13.5.3

## Testing
- `dotnet build eShop.Web.slnf --nologo`
- `dotnet test --solution eShop.Web.slnf --no-build --no-progress --output detailed` (122 passed)
- `aspire start --isolated --non-interactive` and `aspire wait webapp --non-interactive`